### PR TITLE
Enable vaccination certificate uploads

### DIFF
--- a/hub/settings.py
+++ b/hub/settings.py
@@ -124,3 +124,7 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# File upload settings
+MEDIA_ROOT = BASE_DIR / "uploads"
+MEDIA_URL = "/uploads/"

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -16,8 +16,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path("", include("server.urls")),
     path("admin/", admin.site.urls),
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/server/templates/registration.html
+++ b/server/templates/registration.html
@@ -2,7 +2,7 @@
 
 {% block content %}
   <h1>Registration</h1>
-  <form method="POST">
+  <form method="POST" enctype="multipart/form-data">
     {% csrf_token %}
     <h3>User details</h3>
     {{ user_form.as_p }}

--- a/server/views.py
+++ b/server/views.py
@@ -12,7 +12,7 @@ def registration_view(request):
         user_form = UserForm(request.POST)
         player_form = PlayerForm(request.POST)
         membership_form = MembershipForm(request.POST)
-        vaccination_form = VaccinationForm(request.POST)
+        vaccination_form = VaccinationForm(request.POST, request.FILES)
 
         if (
             user_form.is_valid()


### PR DESCRIPTION
Enable vaccination certificate uploads to `uploads/` directory at project root by changes to following project files: 
`hub/settings.py`, 
`hub/urls.py` 
`server/templates/registration.html` 
`server/views.py`