### PR TITLE
Rounding spirit scores to fix large floating points

### DIFF
--- a/server/tournament.py
+++ b/server/tournament.py
@@ -532,9 +532,12 @@ def update_tournament_spirit_rankings(tournament: Tournament) -> None:
                     + float(spirit_score.communication)
                 )
                 matches_count += 1
-        
+
         spirit_ranking.append(
-            {"team_id": team.id, "points": round(points / matches_count, ndigits=1) if matches_count > 0 else points}
+            {
+                "team_id": team.id,
+                "points": round(points / matches_count, ndigits=1) if matches_count > 0 else points,
+            }
         )
 
     spirit_ranking.sort(key=lambda x: x["points"], reverse=True)

--- a/server/tournament.py
+++ b/server/tournament.py
@@ -532,9 +532,9 @@ def update_tournament_spirit_rankings(tournament: Tournament) -> None:
                     + float(spirit_score.communication)
                 )
                 matches_count += 1
-
+        
         spirit_ranking.append(
-            {"team_id": team.id, "points": points / matches_count if matches_count > 0 else points}
+            {"team_id": team.id, "points": round(points / matches_count, ndigits=1) if matches_count > 0 else points}
         )
 
     spirit_ranking.sort(key=lambda x: x["points"], reverse=True)


### PR DESCRIPTION
Fixing large floating points by rounding out the spirit scores. Fixes #110