### PR TITLE
Display spirit scores rounded to 1 decimal place

### DIFF
--- a/frontend/src/components/Tournament.js
+++ b/frontend/src/components/Tournament.js
@@ -221,7 +221,9 @@ const Tournament = () => {
                       {teamsMap()[spirit.team_id]?.name}
                     </A>
                   </td>
-                  <td class="px-6 py-4">{spirit.points}</td>
+                  <td class="px-6 py-4">
+                    {Math.round(spirit.points * 10) / 10}
+                  </td>
                 </tr>
               )}
             </For>


### PR DESCRIPTION
https://hub.indiaultimate.org/tournament/beach-nationals-2023 
spirit scores appear without rounding. The last PR on this rounded the spirit scores while they're saved in the DB, so this wouldn't have applied for completed tournaments

```python
spirit_ranking.append(
            {
                "team_id": team.id,
                "points": round(points / matches_count, ndigits=1) if matches_count > 0 else points,
            }
        )
```

![image](https://github.com/india-ultimate/hub/assets/39093537/f0025a6c-7219-4814-ab50-433b98e0c1c9)
