### PR TITLE
 Remove tournaments in pools, brackets in matches response

### DIFF
--- a/server/schema.py
+++ b/server/schema.py
@@ -521,11 +521,9 @@ class TournamentUpdateSeedingSchema(Schema):
 
 
 class PoolSchema(ModelSchema):
-    tournament: TournamentSchema
-
     class Config:
         model = Pool
-        model_fields = "__all__"
+        model_exclude = ["tournament"]
 
 
 class PoolCreateSchema(Schema):
@@ -535,19 +533,15 @@ class PoolCreateSchema(Schema):
 
 
 class CrossPoolSchema(ModelSchema):
-    tournament: TournamentSchema
-
     class Config:
         model = CrossPool
-        model_fields = "__all__"
+        model_exclude = ["tournament"]
 
 
 class BracketSchema(ModelSchema):
-    tournament: TournamentSchema
-
     class Config:
         model = Bracket
-        model_fields = "__all__"
+        model_exclude = ["tournament"]
 
 
 class BracketCreateSchema(Schema):
@@ -556,11 +550,9 @@ class BracketCreateSchema(Schema):
 
 
 class PositionPoolSchema(ModelSchema):
-    tournament: TournamentSchema
-
     class Config:
         model = PositionPool
-        model_fields = "__all__"
+        model_exclude = ["tournament"]
 
 
 class PositionPoolCreateSchema(Schema):
@@ -587,7 +579,6 @@ class SpiritScoreSchema(ModelSchema):
 
 
 class MatchSchema(ModelSchema):
-    tournament: TournamentSchema
     pool: PoolSchema | None
     cross_pool: CrossPoolSchema | None
     bracket: BracketSchema | None
@@ -603,7 +594,7 @@ class MatchSchema(ModelSchema):
 
     class Config:
         model = Match
-        model_fields = "__all__"
+        model_exclude = ["tournament"]
 
 
 class MatchCreateSchema(Schema):

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -1421,8 +1421,9 @@ class TestTournaments(ApiBaseTestCase):
             {"team_id": 14, "points": 0.0, "self_points": 0.0, "rank": 3},
         ]
 
-        print(match["tournament"]["spirit_ranking"])
-        self.assertEqual(expected_tournament_spirit_ranking, match["tournament"]["spirit_ranking"])
+        self.tournament.refresh_from_db()
+        print(self.tournament.spirit_ranking)
+        self.assertEqual(expected_tournament_spirit_ranking, self.tournament.spirit_ranking)
 
     def test_invalid_submit_spirit_score(self) -> None:
         invalid_matches = Match.objects.filter(tournament=self.tournament).filter(


### PR DESCRIPTION
Matches, Pools and Bracket responses don't need to include tournament data Due to relations to tournament and pools in the matches model, we end up sending the tournament object multiple times in the response.

From #214 