### PR TITLE
Add a help/support widget that sends an email with the form content

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -5,6 +5,7 @@ import { lazy } from "solid-js";
 import { useStore } from "../store";
 import Footer from "./Footer";
 import Header from "./Header";
+import HelpButton from "./HelpButton";
 import ScrollUpButton from "./ScrollUpButton";
 import UserRoute from "./UserRoute";
 
@@ -160,6 +161,7 @@ export default function App() {
             </div>
           </section>
           <ScrollUpButton />
+          <HelpButton />
           <Footer />
         </div>
       </div>

--- a/frontend/src/components/ContactForm.js
+++ b/frontend/src/components/ContactForm.js
@@ -1,0 +1,121 @@
+import { createForm, maxSize, required } from "@modular-forms/solid";
+import { createSignal, Show } from "solid-js";
+
+import { Spinner } from "../icons";
+import { getCookie } from "../utils";
+import FileInput from "./FileInput";
+import TextAreaInput from "./TextAreaInput";
+import TextInput from "./TextInput";
+
+const ContactForm = props => {
+  const initialValues = {};
+  const [status, setStatus] = createSignal("");
+
+  const [contactForm, { Form, Field }] = createForm({
+    initialValues,
+    validateOn: "touched",
+    revalidateOn: "touched"
+  });
+
+  const handleSubmit = async values => {
+    const { attachment, ...data } = values;
+    const formData = new FormData();
+    formData.append("contact_form", JSON.stringify(data));
+    formData.append("attachment", attachment);
+
+    setStatus("");
+
+    try {
+      const response = await fetch("/api/contact", {
+        method: "POST",
+        headers: {
+          "X-CSRFToken": getCookie("csrftoken")
+        },
+        body: formData
+      });
+      if (response.ok) {
+        setStatus("The form has been submitted! ✨");
+      } else {
+        const message = await response.json();
+        const text = message?.message || JSON.stringify(message);
+        setStatus(`${text}`);
+      }
+    } catch (error) {
+      setStatus(`An error occurred: ${error}`);
+    }
+  };
+
+  return (
+    <Form
+      class="text-sm dark:text-white"
+      onSubmit={values => handleSubmit(values)}
+    >
+      <Field name="subject" validate={[required("Please enter a subject.")]}>
+        {(field, props) => (
+          <TextInput
+            {...props}
+            value={field.value}
+            error={field.error}
+            type="text"
+            label="Subject"
+            placeholder="Please help me with ..."
+            required
+          />
+        )}
+      </Field>
+      <Field
+        name="description"
+        validate={[required("Please enter a description.")]}
+      >
+        {(field, props) => (
+          <TextAreaInput
+            {...props}
+            value={field.value}
+            error={field.error}
+            label="Description"
+            placeholder="I am unable to get this to work. Please help..."
+            required
+          />
+        )}
+      </Field>
+      <Field
+        name="attachment"
+        type="File"
+        validate={[
+          maxSize(5 * 1024 * 1024, "Please upload a file smaller than 5MB.")
+        ]}
+      >
+        {(field, props) => (
+          <FileInput
+            {...props}
+            accept={"image/*,application/pdf,application/zip"}
+            value={field.value}
+            error={field.error}
+            label="Upload attachment"
+          />
+        )}
+      </Field>
+      <button
+        type="submit"
+        class="w-full rounded-lg bg-blue-700 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-800 focus:outline-none focus:ring-4 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 sm:w-auto"
+        disabled={contactForm.submitting}
+      >
+        Submit
+      </button>
+      <a
+        class="mx-2.5 w-full rounded-lg bg-gray-700 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-gray-800 focus:outline-none focus:ring-4 focus:ring-gray-300 dark:bg-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-800 sm:w-auto"
+        disabled={contactForm.submitting}
+        href="#"
+        onClick={props.close}
+      >
+        Close
+      </a>
+      <Show when={contactForm.submitting}>
+        <Spinner />
+      </Show>
+      <p>{status()}</p>
+    </Form>
+  );
+};
+
+export default ContactForm;

--- a/frontend/src/components/HelpButton.js
+++ b/frontend/src/components/HelpButton.js
@@ -1,0 +1,31 @@
+import { createSignal, Show } from "solid-js";
+
+import { useStore } from "../store";
+import ContactForm from "./ContactForm";
+
+const HelpButton = () => {
+  const [isOpen, setIsOpen] = createSignal(false);
+  const [store] = useStore();
+
+  const toggleOpen = () => setIsOpen(!isOpen());
+
+  return (
+    <Show when={store?.userFetched && store?.data?.username}>
+      <div class="fixed bottom-0 right-4">
+        <button
+          class="focus:shadow-outline rounded-full bg-purple-500 px-4 py-2 font-bold text-white hover:bg-purple-700 focus:outline-none"
+          onClick={toggleOpen}
+        >
+          ? Help
+        </button>
+        {isOpen() && (
+          <div class="absolute bottom-16 right-0 w-96 rounded-lg border border-purple-400 bg-white p-4 shadow dark:bg-gray-900">
+            <ContactForm close={() => setIsOpen(false)} />
+          </div>
+        )}
+      </div>
+    </Show>
+  );
+};
+
+export default HelpButton;

--- a/frontend/src/components/ScrollUpButton.js
+++ b/frontend/src/components/ScrollUpButton.js
@@ -30,7 +30,7 @@ const ScrollUpButton = () => {
       onClick={scrollToTop}
       class={clsx(
         visible() ? "visible opacity-100" : "invisible opacity-0",
-        "fixed bottom-6 right-4 me-2 inline-flex items-center rounded-full bg-blue-700 p-2 text-center text-sm font-medium text-white transition-all duration-300 ease-in-out hover:bg-blue-800 focus:outline-none dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 md:bottom-10 md:right-8"
+        "fixed bottom-12 right-4 me-2 inline-flex items-center rounded-full bg-blue-700 p-2 text-center text-sm font-medium text-white transition-all duration-300 ease-in-out hover:bg-blue-800 focus:outline-none dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 md:bottom-10 md:right-8"
       )}
     >
       <svg

--- a/frontend/src/components/TextAreaInput.js
+++ b/frontend/src/components/TextAreaInput.js
@@ -1,0 +1,57 @@
+import clsx from "clsx";
+import { createMemo, splitProps } from "solid-js";
+
+import InputError from "./InputError";
+import InputLabel from "./InputLabel";
+
+/**
+ * Textarea input field that users can type into. Various decorations can be
+ * displayed in or around the field to communicate the entry requirements.
+ */
+const TextAreaInput = props => {
+  // Split textarea element props
+  const [, textAreaProps] = splitProps(props, [
+    "class",
+    "value",
+    "label",
+    "error",
+    "padding"
+  ]);
+
+  // Create memoized value
+  const getValue = createMemo(
+    prevValue =>
+      props.value === undefined
+        ? ""
+        : !Number.isNaN(props.value)
+        ? props.value
+        : prevValue,
+    ""
+  );
+
+  return (
+    <div class={clsx(!props.padding && "px-8 lg:px-10", props.class)}>
+      <InputLabel
+        name={props.name}
+        label={props.label}
+        required={props.required}
+      />
+      <textarea
+        {...textAreaProps}
+        class={clsx(
+          "h-28 w-full rounded-2xl border-2 bg-white p-5 outline-none placeholder:text-slate-300 dark:bg-gray-900 dark:placeholder:text-slate-700 md:h-36 md:text-lg lg:h-40 lg:px-6 lg:text-xl",
+          props.error
+            ? "border-red-600/50 dark:border-red-400/50"
+            : "border-slate-200 hover:border-slate-300 focus:border-sky-600/50 dark:border-slate-800 dark:hover:border-slate-700 dark:focus:border-sky-400/50"
+        )}
+        id={props.name}
+        value={getValue()}
+        aria-invalid={!!props.error}
+        aria-errormessage={`${props.name}-error`}
+      />
+      <InputError name={props.name} error={props.error} />
+    </div>
+  );
+};
+
+export default TextAreaInput;

--- a/hub/settings.py
+++ b/hub/settings.py
@@ -186,6 +186,9 @@ EMAIL_USE_TLS = True
 # OTP settings
 OTP_EMAIL_HASH_KEY = os.environ.get("OTP_EMAIL_HASH_KEY", "")
 
+# Support email
+EMAIL_SUPPORT = os.environ.get("EMAIL_SUPPORT", EMAIL_HOST_USER)
+
 
 ########################################################################
 import django_stubs_ext

--- a/hub/settings.py
+++ b/hub/settings.py
@@ -178,7 +178,7 @@ WEBPACK_SERVER_PORT = os.environ.get("WEBPACK_SERVER_PORT", 3000)
 # Email settings
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = "smtp.gmail.com"
-EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "admin@indiaultimate.org")
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True

--- a/server/schema.py
+++ b/server/schema.py
@@ -645,3 +645,8 @@ class UserAccessSchema(Schema):
 
 class TournamentRulesSchema(Schema):
     rules: str
+
+
+class ContactFormSchema(Schema):
+    subject: str
+    description: str

--- a/server/tests/base.py
+++ b/server/tests/base.py
@@ -145,7 +145,9 @@ class ApiBaseTestCase(TestCase):
         super().setUp()
         self.username = "username@foo.com"
         self.password = "password"
-        self.user = user = User.objects.create(username=self.username, email=self.username)
+        self.user = user = User.objects.create(
+            username=self.username, email=self.username, first_name="John", last_name="Williamson"
+        )
         user.set_password(self.password)
         user.save()
         person = UCPerson.objects.create(email=self.username, slug="username")

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -92,7 +92,7 @@ class TestRegistration(ApiBaseTestCase):
         c = self.client
 
         self.assertEqual("", self.player.user.phone)
-        self.assertEqual("", self.player.user.first_name)
+        self.assertEqual("John", self.player.user.first_name)
         self.assertEqual("", self.player.city)
 
         data = {


### PR DESCRIPTION
The idea is to configure a Zulip stream email address so that the support requests come directly to Zulip for the developers to handle them. We previously had a freshworks support widget, but freshworks claims of being a [free forever service](http://web.archive.org/web/20231124142418/https://www.freshworks.com/freshdesk/pricing/) turn out to be untrue and our support widget stopped working.

![image](https://github.com/india-ultimate/hub/assets/315678/1afba62b-5297-4964-9a6c-ca0dce4b2c25)
