### PR TITLE
Don't ignore warnings from eslint

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "css-loader": "^6.8.1",
     "eslint": "^8.46.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "eslint-plugin-solid": "^0.12.1",
+    "eslint-plugin-solid": "^0.13.0",
     "eslint-plugin-unused-imports": "^3.0.0",
     "flowbite": "^1.7.0",
     "html-webpack-plugin": "^5.5.3",

--- a/frontend/src/components/CheckMemberships.js
+++ b/frontend/src/components/CheckMemberships.js
@@ -1,56 +1,55 @@
 import { createForm, required } from "@modular-forms/solid";
-import { createSignal, For } from "solid-js";
+import { createSignal, For, Show } from "solid-js";
 
 import { getCookie } from "../utils";
 import FileInput from "./FileInput";
 
 const MembershipStatusTable = props => {
-  if (!props.data || props.data.length === 0) {
-    return <p>No data found in the CSV</p>;
-  }
-
-  const columns = Object.keys(props.data[0]);
-
   return (
-    <div class="relative overflow-x-auto">
-      <table class="w-full border border-gray-300 text-left text-sm">
-        <thead>
-          <tr>
-            <For each={columns}>
-              {column => <th class="bg-gray-200 px-4 py-2">{column}</th>}
+    <Show
+      fallback={<p>No data found in the CSV</p>}
+      when={props?.data?.length || 0 > 0}
+    >
+      <div class="relative overflow-x-auto">
+        <table class="w-full border border-gray-300 text-left text-sm">
+          <thead>
+            <tr>
+              <For each={props.data[0]}>
+                {column => <th class="bg-gray-200 px-4 py-2">{column}</th>}
+              </For>
+            </tr>
+          </thead>
+          <tbody>
+            <For each={props.data}>
+              {row => (
+                <tr
+                  class={
+                    row.membership_status
+                      ? "bg-green-200 dark:bg-green-700"
+                      : "bg-red-800 text-white"
+                  }
+                >
+                  <For each={props.data[0]}>
+                    {column => {
+                      const value = row[column];
+                      return (
+                        <td class="px-4 py-2">
+                          {typeof value === "boolean"
+                            ? value
+                              ? "Y"
+                              : "N"
+                            : value}
+                        </td>
+                      );
+                    }}
+                  </For>
+                </tr>
+              )}
             </For>
-          </tr>
-        </thead>
-        <tbody>
-          <For each={props.data}>
-            {row => (
-              <tr
-                class={
-                  row.membership_status
-                    ? "bg-green-200 dark:bg-green-700"
-                    : "bg-red-800 text-white"
-                }
-              >
-                <For each={columns}>
-                  {column => {
-                    const value = row[column];
-                    return (
-                      <td class="px-4 py-2">
-                        {typeof value === "boolean"
-                          ? value
-                            ? "Y"
-                            : "N"
-                          : value}
-                      </td>
-                    );
-                  }}
-                </For>
-              </tr>
-            )}
-          </For>
-        </tbody>
-      </table>
-    </div>
+          </tbody>
+        </table>
+      </div>
+    </Show>
   );
 };
 

--- a/frontend/src/components/CheckMemberships.js
+++ b/frontend/src/components/CheckMemberships.js
@@ -63,6 +63,8 @@ const CheckMemberships = () => {
   });
 
   const handleSubmit = async values => {
+    // This is an event handler, but the eslint-plugin-solid doesn't seem to identify it?
+    // eslint-disable-next-line solid/reactivity
     const { info_csv } = values;
     const formData = new FormData();
     formData.append("info_csv", info_csv);
@@ -90,7 +92,7 @@ const CheckMemberships = () => {
   return (
     <Form
       class="my-6 space-y-6 md:space-y-7 lg:space-y-8"
-      onSubmit={values => handleSubmit(values)}
+      onSubmit={handleSubmit}
     >
       <div
         class="mb-4 rounded-lg bg-blue-50 p-4 text-sm text-blue-800 dark:bg-gray-800 dark:text-blue-400"

--- a/frontend/src/components/ContactForm.js
+++ b/frontend/src/components/ContactForm.js
@@ -46,10 +46,7 @@ const ContactForm = props => {
   };
 
   return (
-    <Form
-      class="text-sm dark:text-white"
-      onSubmit={values => handleSubmit(values)}
-    >
+    <Form class="text-sm dark:text-white" onSubmit={handleSubmit}>
       <Field name="subject" validate={[required("Please enter a subject.")]}>
         {(field, props) => (
           <TextInput
@@ -105,8 +102,7 @@ const ContactForm = props => {
       <a
         class="mx-2.5 rounded-lg bg-gray-700 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-gray-800 focus:outline-none focus:ring-4 focus:ring-gray-300 dark:bg-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-800 sm:w-auto"
         disabled={contactForm.submitting}
-        href="#"
-        onClick={props.close}
+        onClick={() => props.close()}
       >
         Close
       </a>

--- a/frontend/src/components/Registration.js
+++ b/frontend/src/components/Registration.js
@@ -57,17 +57,20 @@ const RegistrationForm = props => {
     return store?.data?.email !== value;
   };
 
-  const [ward, setWard] = createSignal(props.ward);
+  const [ward, setWard] = createSignal(false);
+
+  const [selfForm, setSelfForm] = createSignal(true);
+
+  createEffect(() => {
+    setSelfForm(!ward() && !props.others);
+    setWard(props.ward);
+    setSelfForm(!props.ward && !props.others);
+  });
 
   const validateDateOfBirth = value => {
     const age = getAge(value);
     return ward() ? age < majorAge : true;
   };
-
-  const [selfForm, setSelfForm] = createSignal(!props.ward && !props.others);
-  createEffect(() => {
-    setSelfForm(!ward() && !props.others);
-  });
 
   const initialValues = {};
 

--- a/frontend/src/components/StatusStepper.js
+++ b/frontend/src/components/StatusStepper.js
@@ -13,25 +13,35 @@ import {
   shieldExclamation,
   xCircle
 } from "solid-heroicons/solid-mini";
-import { Match, Switch } from "solid-js";
+import { createEffect, createSignal, Match, Switch } from "solid-js";
 
 import { getStatusAndPercent } from "../utils";
 
 const Step = props => {
-  const liClass = clsx(
-    props?.color !== "gray"
-      ? `flex w-full items-center text-${props.color}-600 dark:text-${props.color}-500 space-x-2.5`
-      : "flex w-full items-center space-x-2.5 text-gray-500 dark:text-gray-400"
-  );
-  const iconClass = clsx(
-    "flex items-center justify-center w-10 h-10 rounded-full lg:h-12 lg:w-12 shrink-0",
-    props?.color && `bg-${props.color}-100 dark:bg-${props.color}-700`,
-    !props?.color && "bg-gray-100 dark:bg-gray-700"
-  );
+  const [li, setLi] = createSignal("");
+  const [icon, setIcon] = createSignal("");
+
+  createEffect(() => {
+    setLi(
+      clsx(
+        props?.color !== "gray"
+          ? `flex w-full items-center text-${props.color}-600 dark:text-${props.color}-500 space-x-2.5`
+          : "flex w-full items-center space-x-2.5 text-gray-500 dark:text-gray-400"
+      )
+    );
+    setIcon(
+      clsx(
+        "flex items-center justify-center w-10 h-10 rounded-full lg:h-12 lg:w-12 shrink-0",
+        props?.color && `bg-${props.color}-100 dark:bg-${props.color}-700`,
+        !props?.color && "bg-gray-100 dark:bg-gray-700"
+      )
+    );
+  });
+
   return (
-    <li class={liClass}>
+    <li class={li()}>
       <A class="flex items-center" href={props.link || ""}>
-        <span class={iconClass}>
+        <span class={icon()}>
           <Icon path={props.icon} style={{ width: "20px" }} />
         </span>
         <span class="ml-2">
@@ -43,13 +53,19 @@ const Step = props => {
 };
 
 const StatusStepper = props => {
-  const { status, percent } = getStatusAndPercent(props?.player);
+  const [status, setStatus] = createSignal({});
+  const [percent, setPercent] = createSignal(0);
+  createEffect(() => {
+    const { status, percent } = getStatusAndPercent(props?.player);
+    setStatus(status);
+    setPercent(percent);
+  });
   return (
     <div class="my-8">
       <div class="my-4 flex justify-between">
         <span class="text-center text-base font-medium dark:text-white">
           <div class="text-4xl font-bold text-gray-900 dark:text-white">
-            {percent}%
+            {percent()}%
           </div>
           of the profile is complete
         </span>
@@ -57,14 +73,14 @@ const StatusStepper = props => {
           <div class="h-2.5 w-full rounded-full bg-gray-200 dark:bg-gray-700">
             <div
               class={clsx(
-                percent < 100 ? "bg-red-400" : "bg-green-600",
+                percent() < 100 ? "bg-red-400" : "bg-green-600",
                 "h-2.5 rounded-full"
               )}
-              style={`width: ${percent}%`}
+              style={{ width: `${percent()}%` }}
             />
           </div>
           <Switch>
-            <Match when={percent < 100}>
+            <Match when={percent() < 100}>
               <p class="text-md mt-2">
                 Complete the profile to participate in India Ultimate events
               </p>
@@ -73,7 +89,7 @@ const StatusStepper = props => {
                 to complete those steps.
               </p>
             </Match>
-            <Match when={percent === 100}>
+            <Match when={percent() === 100}>
               <p>Profile complete! 🎉</p>
             </Match>
           </Switch>
@@ -84,42 +100,42 @@ const StatusStepper = props => {
           title="Profile Info"
           link={`/edit/registration/${props.player.id}`}
           icon={identification}
-          color={status.profile ? "green" : "red"}
+          color={status().profile ? "green" : "red"}
         />
         <Step
           title="Vaccine Info"
-          icon={status.vaccine ? shieldCheck : shieldExclamation}
+          icon={status().vaccine ? shieldCheck : shieldExclamation}
           link={`/vaccination/${props.player.id}`}
-          color={status.vaccine ? "green" : "red"}
+          color={status().vaccine ? "green" : "red"}
         />
         <Step
           title="Ultimate Central profile"
           icon={arrowTopRightOnSquare}
           link={`/uc-login/${props.player.id}`}
-          color={status.ucLink ? "green" : "red"}
+          color={status().ucLink ? "green" : "red"}
         />
         <Step
           title="Membership info"
           icon={currencyRupee}
           link={`/membership/${props.player.id}`}
-          color={status.membership ? "green" : "red"}
+          color={status().membership ? "green" : "red"}
         />
         <Step
           title="Liability Waiver"
-          icon={status.waiver ? handThumbUp : handThumbDown}
-          color={status.waiver ? "green" : "red"}
+          icon={status().waiver ? handThumbUp : handThumbDown}
+          color={status().waiver ? "green" : "red"}
           link={`/waiver/${props.player.id}`}
         />
         <Step
           title="Accreditation"
           icon={
-            status.accreditation
+            status().accreditation
               ? props?.player?.accreditation?.level == "ADV"
                 ? documentCheck
                 : document
               : xCircle
           }
-          color={status.accreditation ? "green" : "red"}
+          color={status().accreditation ? "green" : "red"}
           link={`/accreditation/${props.player.id}`}
           last={true}
         />

--- a/frontend/src/components/UserRoute.js
+++ b/frontend/src/components/UserRoute.js
@@ -70,29 +70,33 @@ const WithUserData = props => {
 };
 
 const UserRoute = props => {
-  if (props.element) {
-    return (
-      <Route
-        {...props}
-        component={null}
-        element={
-          <WithUserData admin={props.admin}>{props.element}</WithUserData>
-        }
-      />
-    );
-  } else if (props.component) {
-    return (
-      <Route
-        {...props}
-        component={null}
-        element={
-          <WithUserData admin={props.admin}>
-            <props.component />
-          </WithUserData>
-        }
-      />
-    );
-  }
+  return (
+    <Switch>
+      <Match when={props.element}>
+        <Route
+          {...props}
+          component={null}
+          element={
+            <WithUserData admin={props.admin}>{props.element}</WithUserData>
+          }
+        />
+      </Match>
+      <Match when={props.component}>
+        <Route
+          {...props}
+          component={null}
+          element={
+            <WithUserData admin={props.admin}>
+              <props.component />
+            </WithUserData>
+          }
+        />
+      </Match>
+      <Match when={!props.component && !props.element}>
+        {/* We never get here, since Route component takes care of 404ing the page */}
+      </Match>
+    </Switch>
+  );
 };
 
 export default UserRoute;

--- a/frontend/src/components/ValidateTransactions.js
+++ b/frontend/src/components/ValidateTransactions.js
@@ -39,6 +39,8 @@ const ValidateTransactions = () => {
   });
 
   const handleSubmit = async values => {
+    // This is an event handler, but the eslint-plugin-solid doesn't seem to identify it?
+    // eslint-disable-next-line solid/reactivity
     const { bank_statement } = values;
 
     const formData = new FormData();
@@ -85,7 +87,7 @@ const ValidateTransactions = () => {
       </label>
       <Form
         class="my-6 space-y-6 md:space-y-7 lg:space-y-8"
-        onSubmit={values => handleSubmit(values)}
+        onSubmit={handleSubmit}
       >
         <div class="space-y-8">
           <Field

--- a/frontend/src/components/Waiver.js
+++ b/frontend/src/components/Waiver.js
@@ -328,10 +328,11 @@ const WaiverForm = props => {
   const [isLegal, setIsLegal] = createSignal(false);
   const [waiverSign, setWaiverSign] = createSignal(false);
   const [enableSubmit, setEnableSubmit] = createSignal(false);
-  const [detailed, setDetailed] = createSignal(!props.signed);
+  const [detailed, setDetailed] = createSignal(false);
 
   createEffect(() => {
     setEnableSubmit(waiverSign() && isLegal());
+    setDetailed(!props.signed);
   });
 
   createEffect(() => {

--- a/frontend/src/components/tournament/ReorderTeams.js
+++ b/frontend/src/components/tournament/ReorderTeams.js
@@ -19,7 +19,7 @@ const TeamInfo = props => (
 );
 
 const Sortable = props => {
-  const sortable = createSortable(props.teamId);
+  const sortable = createSortable(props.teamId); // eslint-disable-line solid/reactivity
   const [state] = useDragDropContext();
   return (
     <div

--- a/frontend/src/skeletons/Players.js
+++ b/frontend/src/skeletons/Players.js
@@ -23,8 +23,11 @@ const Player = () => {
 };
 
 const PlayersSkeleton = props => {
-  const array = Array.from({ length: props.n }, (value, index) => index);
-  return <For each={array}>{() => <Player />}</For>;
+  return (
+    <For each={Array.from({ length: props.n }, (value, index) => index)}>
+      {() => <Player />}
+    </For>
+  );
 };
 
 export default PlayersSkeleton;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -980,7 +980,7 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eslint-community/eslint-utils@^4.2.0":
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
@@ -1246,6 +1246,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
   integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
+"@types/json-schema@^7.0.12":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
 "@types/mdast@^3.0.0":
   version "3.0.12"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.12.tgz#beeb511b977c875a5b0cc92eab6fcac2f0895514"
@@ -1293,10 +1298,10 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
-"@types/semver@^7.3.12":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
-  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
+"@types/semver@^7.5.0":
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
+  integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
 
 "@types/send@*":
   version "0.17.1"
@@ -1341,53 +1346,52 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/scope-manager@5.62.0":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz#d9457ccc6a0b8d6b37d0eb252a23022478c5460c"
-  integrity sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==
+"@typescript-eslint/scope-manager@6.13.2":
+  version "6.13.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.13.2.tgz#5fa4e4adace028dafac212c770640b94e7b61052"
+  integrity sha512-CXQA0xo7z6x13FeDYCgBkjWzNqzBn8RXaE3QVQVIUm74fWJLkJkaHmHdKStrxQllGh6Q4eUGyNpMe0b1hMkXFA==
   dependencies:
-    "@typescript-eslint/types" "5.62.0"
-    "@typescript-eslint/visitor-keys" "5.62.0"
+    "@typescript-eslint/types" "6.13.2"
+    "@typescript-eslint/visitor-keys" "6.13.2"
 
-"@typescript-eslint/types@5.62.0":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
-  integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
+"@typescript-eslint/types@6.13.2":
+  version "6.13.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.13.2.tgz#c044aac24c2f6cefb8e921e397acad5417dd0ae6"
+  integrity sha512-7sxbQ+EMRubQc3wTfTsycgYpSujyVbI1xw+3UMRUcrhSy+pN09y/lWzeKDbvhoqcRbHdc+APLs/PWYi/cisLPg==
 
-"@typescript-eslint/typescript-estree@5.62.0":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz#7d17794b77fabcac615d6a48fb143330d962eb9b"
-  integrity sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==
+"@typescript-eslint/typescript-estree@6.13.2":
+  version "6.13.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.2.tgz#ae556ee154c1acf025b48d37c3ef95a1d55da258"
+  integrity sha512-SuD8YLQv6WHnOEtKv8D6HZUzOub855cfPnPMKvdM/Bh1plv1f7Q/0iFUDLKKlxHcEstQnaUU4QZskgQq74t+3w==
   dependencies:
-    "@typescript-eslint/types" "5.62.0"
-    "@typescript-eslint/visitor-keys" "5.62.0"
+    "@typescript-eslint/types" "6.13.2"
+    "@typescript-eslint/visitor-keys" "6.13.2"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
 
-"@typescript-eslint/utils@^5.55.0":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
-  integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
+"@typescript-eslint/utils@^6.4.0":
+  version "6.13.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.13.2.tgz#8eb89e53adc6d703a879b131e528807245486f89"
+  integrity sha512-b9Ptq4eAZUym4idijCRzl61oPCwwREcfDI8xGk751Vhzig5fFZR9CyzDz4Sp/nxSLBYxUPyh4QdIDqWykFhNmQ==
   dependencies:
-    "@eslint-community/eslint-utils" "^4.2.0"
-    "@types/json-schema" "^7.0.9"
-    "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.62.0"
-    "@typescript-eslint/types" "5.62.0"
-    "@typescript-eslint/typescript-estree" "5.62.0"
-    eslint-scope "^5.1.1"
-    semver "^7.3.7"
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@types/json-schema" "^7.0.12"
+    "@types/semver" "^7.5.0"
+    "@typescript-eslint/scope-manager" "6.13.2"
+    "@typescript-eslint/types" "6.13.2"
+    "@typescript-eslint/typescript-estree" "6.13.2"
+    semver "^7.5.4"
 
-"@typescript-eslint/visitor-keys@5.62.0":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz#2174011917ce582875954ffe2f6912d5931e353e"
-  integrity sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==
+"@typescript-eslint/visitor-keys@6.13.2":
+  version "6.13.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.2.tgz#e0a4a80cf842bb08e6127b903284166ac4a5594c"
+  integrity sha512-OGznFs0eAQXJsp+xSd6k/O1UbFi/K/L7WjqeRoFE7vadjAF9y0uppXhYNQNEqygjou782maGClOoZwPqF0Drlw==
   dependencies:
-    "@typescript-eslint/types" "5.62.0"
-    eslint-visitor-keys "^3.3.0"
+    "@typescript-eslint/types" "6.13.2"
+    eslint-visitor-keys "^3.4.1"
 
 "@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
   version "1.11.6"
@@ -2470,12 +2474,12 @@ eslint-plugin-simple-import-sort@^10.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz#cc4ceaa81ba73252427062705b64321946f61351"
   integrity sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==
 
-eslint-plugin-solid@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-solid/-/eslint-plugin-solid-0.12.1.tgz#6035e9e992620f916fd9d14ad9eb2bbf62a76973"
-  integrity sha512-fM0sEg9PcS1mcNbWklwc+W/lOv1/XyEwXf53HmFFy4GOA8E3u41h8JW+hc+Vv1m3kh01umKoTalOTET08zKdAQ==
+eslint-plugin-solid@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-solid/-/eslint-plugin-solid-0.13.0.tgz#5bbf5caf70fc82bce06acb925eaad955ba4167bc"
+  integrity sha512-Sutd+DxEGu9+Z9ITtHKXRAClxVe1a6C1XQZSuN8iBsMy0IAVEc6Tca1UYgc7tD2ZrRRjZKB9mohBOaZl5NJLgg==
   dependencies:
-    "@typescript-eslint/utils" "^5.55.0"
+    "@typescript-eslint/utils" "^6.4.0"
     is-html "^2.0.0"
     jsx-ast-utils "^3.3.3"
     kebab-case "^1.0.2"
@@ -2494,7 +2498,7 @@ eslint-rule-composer@^0.3.0:
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
   integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
-eslint-scope@5.1.1, eslint-scope@^5.1.1:
+eslint-scope@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -4924,17 +4928,17 @@ semver@^6.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.7:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
-  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
-  dependencies:
-    lru-cache "^6.0.0"
-
 semver@^7.3.8:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
   integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -5415,27 +5419,20 @@ trough@^2.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
   integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
 
+ts-api-utils@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
+  integrity sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==
+
 ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
-tslib@^1.8.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tslib@^2.0.3:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
-
-tsutils@^3.21.0:
-  version "3.21.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
-  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
-  dependencies:
-    tslib "^1.8.1"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"

--- a/scripts/lint
+++ b/scripts/lint
@@ -49,6 +49,8 @@ def run() -> None:
             "--config",
             "frontend/package.json",
             "--cache",
+            "--max-warnings",
+            "0",
             "--ext",
             ".js,.ts",
         ],

--- a/scripts/lint
+++ b/scripts/lint
@@ -51,6 +51,7 @@ def run() -> None:
             "--cache",
             "--max-warnings",
             "0",
+            "--no-ignore",
             "--ext",
             ".js,.ts",
         ],

--- a/server/tests/tests.webpack.config.js
+++ b/server/tests/tests.webpack.config.js
@@ -1,4 +1,3 @@
-const path = require("path");
 module.exports = {
   extends: "webpack.config.js",
   devServer: {


### PR DESCRIPTION
In 008bfdb66076d17cdce0c9bb3a6fdd63daa4e888 we fixed an error where we accidentally had some properties "lose" their reactivity, which should've been caught by the eslint-plugin-solid's warnings. But, we disable eslint's warnings in CI because, there were too many of them. 

This commit prevents having warnings from eslint, which means we would be forced to think harder about the code and re-write it, or disable it in exceptional cases if the linter is giving a false positive. 