### PR TITLE
tournament-team: Fix bug when match is in yet-to-fix (YTF) status

### DIFF
--- a/frontend/src/components/TournamentTeam.js
+++ b/frontend/src/components/TournamentTeam.js
@@ -48,14 +48,17 @@ const TournamentTeam = () => {
     () => fetchTournamentTeamMatches(params.tournament_slug, params.team_slug)
   );
 
-  const currTeamNo = match =>
-    params.team_slug === match.team_1.ultimate_central_slug ? 1 : 2;
+  const currTeamNo = match => {
+    if (match.team_1) {
+      return params.team_slug === match.team_1.ultimate_central_slug ? 1 : 2;
+    }
+    return params.team_slug === match.team_2.ultimate_central_slug ? 2 : 1;
+  };
 
-  const oppTeamNo = match =>
-    params.team_slug === match.team_1.ultimate_central_slug ? 2 : 1;
+  const oppTeamNo = match => (currTeamNo(match) === 1 ? 2 : 1);
 
   const matchOutcomeColor = match => {
-    if (match.status === "SCH") {
+    if (match.status === "SCH" || match.status === "YTF") {
       return "blue";
     }
     if (match.status === "COM") {
@@ -225,7 +228,6 @@ const TournamentTeam = () => {
                   <Show when={tournamentDates().length > 1}>
                     <div class="mb-5 ml-1">
                       <h3 class="text-center text-lg font-bold">
-                        {/* Object.groupBy coerces the keys to strings */}
                         Day -{" "}
                         {tournamentDates().indexOf(parseInt(tournamentDate)) +
                           1}


### PR DESCRIPTION
The team matches endpoint returns matches where the current team is present. When one of these matches is in YTF status, either team_1 or team_2 is null. `team_1` was being referenced in the `currTeamNo` function, this would error out when `team_1` is null.

Fixes #267 