### PR TITLE
Throw error object is request fails

### DIFF
--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -791,7 +791,7 @@ export const registerYourselfToSeries = async ({ series_slug, team_slug }) => {
   const data = await response.json();
 
   if (!response.ok) {
-    throw new Error(data?.message || JSON.stringify(data));
+    throw new Error(JSON.stringify(data));
   }
   return data;
 };
@@ -813,7 +813,7 @@ export const addTeamRegistration = async ({ tournament_id, body }) => {
   const data = await response.json();
 
   if (!response.ok) {
-    throw new Error(data?.message || JSON.stringify(data));
+    throw new Error(JSON.stringify(data));
   }
 
   return data;
@@ -859,7 +859,7 @@ export const addToRoster = async ({ event_id, team_id, body }) => {
   const data = await response.json();
 
   if (!response.ok) {
-    throw new Error(data?.message || JSON.stringify(data));
+    throw new Error(JSON.stringify(data));
   }
 
   return data;


### PR DESCRIPTION
Throwing error objects always for adding to tournament roster, event roster and team registration. If not, the error modal won't popup