### PR TITLE
Allow rostering directly from email

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -51,6 +51,7 @@ const SeriesRoster = lazy(() => import("./series/SeriesRoster"));
 // const EditStats = lazy(() => import("./match/stats/EditStats"));
 const EditStatsMin = lazy(() => import("./match/stats/EditMinStats"));
 const ViewStats = lazy(() => import("./match/stats/ViewStats"));
+const EmailInvitationHandler = lazy(() => import("./series/InvitationViaEmail"));
 
 const filters = {
   id: /^\d+$/ // only allow numbers
@@ -117,6 +118,8 @@ export default function App() {
                     path="/tournament/:tournamentSlug/match/:matchId/live"
                     component={ViewStats}
                   />
+                  <Route path="/accept-invitation" component={EmailInvitationHandler} />
+                  <Route path="/decline-invitation" component={EmailInvitationHandler} />
                   {/* Team Public Routes */}
                   <Route path={"/teams"} component={Teams} />
                   <Route path={"/team/:slug"} component={ViewTeam} />

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -118,8 +118,8 @@ export default function App() {
                     path="/tournament/:tournamentSlug/match/:matchId/live"
                     component={ViewStats}
                   />
-                  <Route path="/accept-invitation" component={EmailInvitationHandler} />
-                  <Route path="/decline-invitation" component={EmailInvitationHandler} />
+                  <Route path="/invitation/accept" component={EmailInvitationHandler} />
+                  <Route path="/invitation/decline" component={EmailInvitationHandler} />
                   {/* Team Public Routes */}
                   <Route path={"/teams"} component={Teams} />
                   <Route path={"/team/:slug"} component={ViewTeam} />

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -51,7 +51,9 @@ const SeriesRoster = lazy(() => import("./series/SeriesRoster"));
 // const EditStats = lazy(() => import("./match/stats/EditStats"));
 const EditStatsMin = lazy(() => import("./match/stats/EditMinStats"));
 const ViewStats = lazy(() => import("./match/stats/ViewStats"));
-const EmailInvitationHandler = lazy(() => import("./series/InvitationViaEmail"));
+const EmailInvitationHandler = lazy(() =>
+  import("./series/InvitationViaEmail")
+);
 
 const filters = {
   id: /^\d+$/ // only allow numbers
@@ -118,8 +120,14 @@ export default function App() {
                     path="/tournament/:tournamentSlug/match/:matchId/live"
                     component={ViewStats}
                   />
-                  <Route path="/invitation/accept" component={EmailInvitationHandler} />
-                  <Route path="/invitation/decline" component={EmailInvitationHandler} />
+                  <Route
+                    path="/invitation/accept"
+                    component={EmailInvitationHandler}
+                  />
+                  <Route
+                    path="/invitation/decline"
+                    component={EmailInvitationHandler}
+                  />
                   {/* Team Public Routes */}
                   <Route path={"/teams"} component={Teams} />
                   <Route path={"/team/:slug"} component={ViewTeam} />

--- a/frontend/src/components/series/InvitationViaEmail.js
+++ b/frontend/src/components/series/InvitationViaEmail.js
@@ -1,15 +1,19 @@
-import { createMutation } from "@tanstack/solid-query";
-import { createSignal, onMount, Show, createEffect } from "solid-js";
 import { useNavigate, useSearchParams } from "@solidjs/router";
-import { acceptSeriesInvitationFromEmail, declineSeriesInvitationFromEmail } from "../../queries";
+import { createMutation } from "@tanstack/solid-query";
+import { createEffect, createSignal, onMount, Show } from "solid-js";
+
+import {
+  acceptSeriesInvitationFromEmail,
+  declineSeriesInvitationFromEmail
+} from "../../queries";
 
 const EmailInvitationHandler = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  
+
   const [token, setToken] = createSignal("");
   const [responseMessage, setResponseMessage] = createSignal("");
-  const [isAccepting, setIsAccepting] = createSignal(false);
+  const [setIsAccepting] = createSignal(false);
   const [teamName, setTeamName] = createSignal("");
   const [teamLogo, setTeamLogo] = createSignal("");
   const [fromUser, setFromUser] = createSignal(null);
@@ -21,8 +25,10 @@ const EmailInvitationHandler = () => {
     const urlToken = searchParams.token;
     if (urlToken) {
       setToken(urlToken);
-      const action = window.location.pathname.includes('invitation/accept') ? 'accept' : 'decline';
-      setIsAccepting(action === 'accept');
+      const action = window.location.pathname.includes("invitation/accept")
+        ? "accept"
+        : "decline";
+      setIsAccepting(action === "accept");
       handleInvitation(action);
     } else {
       setResponseMessage("Invalid invitation link. No token found.");
@@ -34,7 +40,7 @@ const EmailInvitationHandler = () => {
       setCountdown(c => {
         if (c <= 1) {
           clearInterval(timer);
-          navigate('/');
+          navigate("/");
           return 0;
         }
         return c - 1;
@@ -46,38 +52,42 @@ const EmailInvitationHandler = () => {
 
   const acceptMutation = createMutation({
     mutationFn: acceptSeriesInvitationFromEmail,
-    onSuccess: (data) => {
+    onSuccess: data => {
       setIsSuccess(true);
-      setResponseMessage(`Invitation accepted successfully`);
+      setResponseMessage("Invitation accepted successfully");
       setTeamName(data.team.name);
       setTeamLogo(data.team.image_url);
       setFromUser(data.from_user);
       setToPlayer(data.to_player);
     },
-    onError: (error) => {
+    onError: error => {
       setIsSuccess(false);
-      setResponseMessage(error.message || "An error occurred while processing your invitation.");
+      setResponseMessage(
+        error.message || "An error occurred while processing your invitation."
+      );
     }
   });
 
   const declineMutation = createMutation({
     mutationFn: declineSeriesInvitationFromEmail,
-    onSuccess: (data) => {
+    onSuccess: data => {
       setIsSuccess(true);
-      setResponseMessage(`Invitation declined successfully`);
+      setResponseMessage("Invitation declined successfully");
       setTeamName(data.team.name);
       setTeamLogo(data.team.image_url);
       setFromUser(data.from_user);
       setToPlayer(data.to_player);
     },
-    onError: (error) => {
+    onError: error => {
       setIsSuccess(false);
-      setResponseMessage(error.message || "An error occurred while processing your invitation.");
+      setResponseMessage(
+        error.message || "An error occurred while processing your invitation."
+      );
     }
   });
 
-  const handleInvitation = (action) => {
-    if (action === 'accept') {
+  const handleInvitation = action => {
+    if (action === "accept") {
       acceptMutation.mutate({ token: token() });
     } else {
       declineMutation.mutate({ token: token() });
@@ -85,45 +95,62 @@ const EmailInvitationHandler = () => {
   };
 
   return (
-    <div class="min-h-screen bg-gray-100 flex flex-col items-center pt-30 py-12 px-4 sm:px-6 lg:px-8">
-      <div class="max-w-md w-full space-y-8 bg-white shadow-xl rounded-xl p-8">
+    <div class="pt-30 flex min-h-screen flex-col items-center bg-gray-100 px-4 py-12 sm:px-6 lg:px-8">
+      <div class="w-full max-w-md space-y-8 rounded-xl bg-white p-8 shadow-xl">
         <Show
           when={!acceptMutation.isLoading && !declineMutation.isLoading}
-          fallback={<p class="text-center text-xl font-semibold text-gray-700">Processing your invitation...</p>}
+          fallback={
+            <p class="text-center text-xl font-semibold text-gray-700">
+              Processing your invitation...
+            </p>
+          }
         >
           <Show
             when={isSuccess()}
             fallback={
               <div class="text-center">
-                <p class="text-xl font-semibold text-red-600 mb-4">{responseMessage()}</p>
+                <p class="mb-4 text-xl font-semibold text-red-600">
+                  {responseMessage()}
+                </p>
               </div>
             }
           >
-            <div class="flex items-center space-x-4 mb-6">
-              <img src={teamLogo()} alt={`${teamName()} logo`} class="w-16 h-16 object-cover rounded-full" />
+            <div class="mb-6 flex items-center space-x-4">
+              <img
+                src={teamLogo()}
+                alt={`${teamName()} logo`}
+                class="h-16 w-16 rounded-full object-cover"
+              />
               <div>
                 <h2 class="text-2xl font-bold text-gray-900">{teamName()}</h2>
                 <Show when={fromUser()}>
-                  <p class="text-sm text-gray-600">Invitation from: {fromUser().full_name}</p>
+                  <p class="text-sm text-gray-600">
+                    Invitation from: {fromUser().full_name}
+                  </p>
                 </Show>
                 <Show when={toPlayer()}>
-                <p class="text-sm text-gray-600">To: {toPlayer().full_name}</p>
+                  <p class="text-sm text-gray-600">
+                    To: {toPlayer().full_name}
+                  </p>
                 </Show>
               </div>
             </div>
-            
-            <div class="bg-gray-50 rounded-lg p-4 mb-6">
-              <p class="text-lg font-medium text-gray-900 mb-2">{responseMessage()}</p>
+
+            <div class="mb-6 rounded-lg bg-gray-50 p-4">
+              <p class="mb-2 text-lg font-medium text-gray-900">
+                {responseMessage()}
+              </p>
             </div>
           </Show>
         </Show>
         <div class="text-center">
-          <p class="text-gray-600 mb-2">
-            Redirecting to homepage in <span class="font-bold">{countdown()}</span> seconds...
+          <p class="mb-2 text-gray-600">
+            Redirecting to homepage in{" "}
+            <span class="font-bold">{countdown()}</span> seconds...
           </p>
           <button
-            onClick={() => navigate('/')}
-            class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition duration-150 ease-in-out"
+            onClick={() => navigate("/")}
+            class="w-full rounded-lg bg-blue-600 px-4 py-2 font-bold text-white transition duration-150 ease-in-out hover:bg-blue-700"
           >
             Go to Homepage
           </button>

--- a/frontend/src/components/series/InvitationViaEmail.js
+++ b/frontend/src/components/series/InvitationViaEmail.js
@@ -1,0 +1,84 @@
+import { createMutation } from "@tanstack/solid-query";
+import { createSignal, onMount, Show } from "solid-js";
+import { useNavigate, useSearchParams } from "@solidjs/router";
+
+import { acceptSeriesInvitationFromEmail, declineSeriesInvitationFromEmail } from "../../queries";
+
+const EmailInvitationHandler = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  
+  const [token, setToken] = createSignal("");
+  const [responseMessage, setResponseMessage] = createSignal("");
+  const [isAccepting, setIsAccepting] = createSignal(false);
+  const [teamName, setTeamName] = createSignal("");
+  const [teamLogo, setTeamLogo] = createSignal("");
+
+  onMount(() => {
+    const urlToken = searchParams.token;
+    if (urlToken) {
+      setToken(urlToken);
+      const action = window.location.pathname.includes('accept-invitation') ? 'accept' : 'decline';
+      setIsAccepting(action === 'accept');
+      handleInvitation(action);
+    } else {
+      setResponseMessage("Invalid invitation link. No token found.");
+    }
+  });
+
+  const acceptMutation = createMutation({
+    mutationFn: acceptSeriesInvitationFromEmail,
+    onSuccess: (data) => {
+      setResponseMessage(`Invitation accepted successfully for ${data.team.name}`);
+      setTeamName(data.team.name);
+      setTeamLogo(data.team.image_url);
+    },
+    onError: (error) => {
+      setResponseMessage(error.message);
+    }
+  });
+
+  const declineMutation = createMutation({
+    mutationFn: declineSeriesInvitationFromEmail,
+    onSuccess: (data) => {
+      setResponseMessage(`Invitation declined successfully for ${data.team.name}`);
+    },
+    onError: (error) => {
+      setResponseMessage(error.message);
+    }
+  });
+
+  const handleInvitation = (action) => {
+    if (action === 'accept') {
+      acceptMutation.mutate({ token: token() });
+    } else {
+      declineMutation.mutate({ token: token() });
+    }
+  };
+
+  return (
+    <div class="min-h-screen bg-gray-100 flex flex-col justify-center items-center">
+      <div class="max-w-md w-full bg-white shadow-md rounded-lg p-8">   
+        <Show
+          when={!acceptMutation.isLoading && !declineMutation.isLoading}
+          fallback={<p>Processing your invitation...</p>}
+        >
+          <p class="mb-4">{responseMessage()}</p>
+          <Show when={teamName()}>
+            <div class="mt-4">
+              <img src={teamLogo()} alt={`${teamName()} logo`} class="mt-2 w-32 h-32 object-cover" />
+            </div>
+          </Show>
+        </Show>
+        <button
+          onClick={() => navigate('/')}
+          class="mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+        >
+          Go to Homepage
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EmailInvitationHandler;

--- a/frontend/src/components/series/InvitationViaEmail.js
+++ b/frontend/src/components/series/InvitationViaEmail.js
@@ -1,5 +1,5 @@
 import { createMutation } from "@tanstack/solid-query";
-import { createSignal, onMount, Show } from "solid-js";
+import { createSignal, onMount, Show, createEffect } from "solid-js";
 import { useNavigate, useSearchParams } from "@solidjs/router";
 
 import { acceptSeriesInvitationFromEmail, declineSeriesInvitationFromEmail } from "../../queries";
@@ -13,16 +13,34 @@ const EmailInvitationHandler = () => {
   const [isAccepting, setIsAccepting] = createSignal(false);
   const [teamName, setTeamName] = createSignal("");
   const [teamLogo, setTeamLogo] = createSignal("");
+  const [countdown, setCountdown] = createSignal(20);
 
   onMount(() => {
     const urlToken = searchParams.token;
     if (urlToken) {
       setToken(urlToken);
-      const action = window.location.pathname.includes('accept-invitation') ? 'accept' : 'decline';
+      const action = window.location.pathname.includes('invitation/accept') ? 'accept' : 'decline';
       setIsAccepting(action === 'accept');
       handleInvitation(action);
     } else {
       setResponseMessage("Invalid invitation link. No token found.");
+    }
+  });
+
+  createEffect(() => {
+    if (!acceptMutation.isLoading && !declineMutation.isLoading) {
+      const timer = setInterval(() => {
+        setCountdown(c => {
+          if (c <= 1) {
+            clearInterval(timer);
+            navigate('/');
+            return 0;
+          }
+          return c - 1;
+        });
+      }, 1000);
+
+      return () => clearInterval(timer);
     }
   });
 
@@ -57,7 +75,7 @@ const EmailInvitationHandler = () => {
   };
 
   return (
-    <div class="min-h-screen bg-gray-100 flex flex-col justify-center items-center">
+    <div class="min-h-screen bg-gray-100 flex flex-col items-center pt-40">
       <div class="max-w-md w-full bg-white shadow-md rounded-lg p-8">   
         <Show
           when={!acceptMutation.isLoading && !declineMutation.isLoading}
@@ -69,10 +87,15 @@ const EmailInvitationHandler = () => {
               <img src={teamLogo()} alt={`${teamName()} logo`} class="mt-2 w-32 h-32 object-cover" />
             </div>
           </Show>
+          <hr class="my-4 border-t border-gray-300" />
+          <p class="text-center text-gray-600">
+            Redirecting to homepage in {countdown()} seconds...
+          </p>
+          <hr class="my-4 border-t border-gray-300" />
         </Show>
         <button
           onClick={() => navigate('/')}
-          class="mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          class="mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-full"
         >
           Go to Homepage
         </button>

--- a/frontend/src/components/series/InvitationViaEmail.js
+++ b/frontend/src/components/series/InvitationViaEmail.js
@@ -1,7 +1,6 @@
 import { createMutation } from "@tanstack/solid-query";
 import { createSignal, onMount, Show, createEffect } from "solid-js";
 import { useNavigate, useSearchParams } from "@solidjs/router";
-
 import { acceptSeriesInvitationFromEmail, declineSeriesInvitationFromEmail } from "../../queries";
 
 const EmailInvitationHandler = () => {
@@ -13,7 +12,10 @@ const EmailInvitationHandler = () => {
   const [isAccepting, setIsAccepting] = createSignal(false);
   const [teamName, setTeamName] = createSignal("");
   const [teamLogo, setTeamLogo] = createSignal("");
+  const [fromUser, setFromUser] = createSignal(null);
+  const [toPlayer, setToPlayer] = createSignal(null);
   const [countdown, setCountdown] = createSignal(20);
+  const [isSuccess, setIsSuccess] = createSignal(false);
 
   onMount(() => {
     const urlToken = searchParams.token;
@@ -28,41 +30,49 @@ const EmailInvitationHandler = () => {
   });
 
   createEffect(() => {
-    if (!acceptMutation.isLoading && !declineMutation.isLoading) {
-      const timer = setInterval(() => {
-        setCountdown(c => {
-          if (c <= 1) {
-            clearInterval(timer);
-            navigate('/');
-            return 0;
-          }
-          return c - 1;
-        });
-      }, 1000);
+    const timer = setInterval(() => {
+      setCountdown(c => {
+        if (c <= 1) {
+          clearInterval(timer);
+          navigate('/');
+          return 0;
+        }
+        return c - 1;
+      });
+    }, 1000);
 
-      return () => clearInterval(timer);
-    }
+    return () => clearInterval(timer);
   });
 
   const acceptMutation = createMutation({
     mutationFn: acceptSeriesInvitationFromEmail,
     onSuccess: (data) => {
-      setResponseMessage(`Invitation accepted successfully for ${data.team.name}`);
+      setIsSuccess(true);
+      setResponseMessage(`Invitation accepted successfully`);
       setTeamName(data.team.name);
       setTeamLogo(data.team.image_url);
+      setFromUser(data.from_user);
+      setToPlayer(data.to_player);
     },
     onError: (error) => {
-      setResponseMessage(error.message);
+      setIsSuccess(false);
+      setResponseMessage(error.message || "An error occurred while processing your invitation.");
     }
   });
 
   const declineMutation = createMutation({
     mutationFn: declineSeriesInvitationFromEmail,
     onSuccess: (data) => {
-      setResponseMessage(`Invitation declined successfully for ${data.team.name}`);
+      setIsSuccess(true);
+      setResponseMessage(`Invitation declined successfully`);
+      setTeamName(data.team.name);
+      setTeamLogo(data.team.image_url);
+      setFromUser(data.from_user);
+      setToPlayer(data.to_player);
     },
     onError: (error) => {
-      setResponseMessage(error.message);
+      setIsSuccess(false);
+      setResponseMessage(error.message || "An error occurred while processing your invitation.");
     }
   });
 
@@ -75,30 +85,49 @@ const EmailInvitationHandler = () => {
   };
 
   return (
-    <div class="min-h-screen bg-gray-100 flex flex-col items-center pt-40">
-      <div class="max-w-md w-full bg-white shadow-md rounded-lg p-8">   
+    <div class="min-h-screen bg-gray-100 flex flex-col items-center pt-30 py-12 px-4 sm:px-6 lg:px-8">
+      <div class="max-w-md w-full space-y-8 bg-white shadow-xl rounded-xl p-8">
         <Show
           when={!acceptMutation.isLoading && !declineMutation.isLoading}
-          fallback={<p>Processing your invitation...</p>}
+          fallback={<p class="text-center text-xl font-semibold text-gray-700">Processing your invitation...</p>}
         >
-          <p class="mb-4">{responseMessage()}</p>
-          <Show when={teamName()}>
-            <div class="mt-4">
-              <img src={teamLogo()} alt={`${teamName()} logo`} class="mt-2 w-32 h-32 object-cover" />
+          <Show
+            when={isSuccess()}
+            fallback={
+              <div class="text-center">
+                <p class="text-xl font-semibold text-red-600 mb-4">{responseMessage()}</p>
+              </div>
+            }
+          >
+            <div class="flex items-center space-x-4 mb-6">
+              <img src={teamLogo()} alt={`${teamName()} logo`} class="w-16 h-16 object-cover rounded-full" />
+              <div>
+                <h2 class="text-2xl font-bold text-gray-900">{teamName()}</h2>
+                <Show when={fromUser()}>
+                  <p class="text-sm text-gray-600">Invitation from: {fromUser().full_name}</p>
+                </Show>
+                <Show when={toPlayer()}>
+                <p class="text-sm text-gray-600">To: {toPlayer().full_name}</p>
+                </Show>
+              </div>
+            </div>
+            
+            <div class="bg-gray-50 rounded-lg p-4 mb-6">
+              <p class="text-lg font-medium text-gray-900 mb-2">{responseMessage()}</p>
             </div>
           </Show>
-          <hr class="my-4 border-t border-gray-300" />
-          <p class="text-center text-gray-600">
-            Redirecting to homepage in {countdown()} seconds...
-          </p>
-          <hr class="my-4 border-t border-gray-300" />
         </Show>
-        <button
-          onClick={() => navigate('/')}
-          class="mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-full"
-        >
-          Go to Homepage
-        </button>
+        <div class="text-center">
+          <p class="text-gray-600 mb-2">
+            Redirecting to homepage in <span class="font-bold">{countdown()}</span> seconds...
+          </p>
+          <button
+            onClick={() => navigate('/')}
+            class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition duration-150 ease-in-out"
+          >
+            Go to Homepage
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -743,6 +743,46 @@ export const revokeInvitation = async ({ invitation_id }) => {
   return data;
 };
 
+export const acceptSeriesInvitationFromEmail = async ({ 
+  token, 
+}) => {
+  const response = await fetch(
+    `/api/series/accept-invitation?token=${token}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      }
+    }
+  );
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data?.message || JSON.stringify(data));
+  }
+  return data;
+};
+
+export const declineSeriesInvitationFromEmail = async ({ 
+  token,
+}) => {
+  const response = await fetch(
+    `/api/series/decline-invitation?token=${token}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      }
+    }
+  );
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data?.message || JSON.stringify(data));
+  }
+  return data;
+};
+
 export const acceptSeriesInvitation = async ({ invitation_id }) => {
   const response = await fetch(
     `/api/series/invitation/${invitation_id}/accept`,

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -743,18 +743,13 @@ export const revokeInvitation = async ({ invitation_id }) => {
   return data;
 };
 
-export const acceptSeriesInvitationFromEmail = async ({ 
-  token, 
-}) => {
-  const response = await fetch(
-    `/api/series/invitation/accept?token=${token}`,
-    {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      }
+export const acceptSeriesInvitationFromEmail = async ({ token }) => {
+  const response = await fetch(`/api/series/invitation/accept?token=${token}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json"
     }
-  );
+  });
   const data = await response.json();
 
   if (!response.ok) {
@@ -763,15 +758,13 @@ export const acceptSeriesInvitationFromEmail = async ({
   return data;
 };
 
-export const declineSeriesInvitationFromEmail = async ({ 
-  token,
-}) => {
+export const declineSeriesInvitationFromEmail = async ({ token }) => {
   const response = await fetch(
     `/api/series/invitation/decline?token=${token}`,
     {
       method: "GET",
       headers: {
-        "Content-Type": "application/json",
+        "Content-Type": "application/json"
       }
     }
   );

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -747,7 +747,7 @@ export const acceptSeriesInvitationFromEmail = async ({
   token, 
 }) => {
   const response = await fetch(
-    `/api/series/accept-invitation?token=${token}`,
+    `/api/series/invitation/accept?token=${token}`,
     {
       method: "GET",
       headers: {
@@ -767,7 +767,7 @@ export const declineSeriesInvitationFromEmail = async ({
   token,
 }) => {
   const response = await fetch(
-    `/api/series/decline-invitation?token=${token}`,
+    `/api/series/invitation/decline?token=${token}`,
     {
       method: "GET",
       headers: {

--- a/hub/settings.py
+++ b/hub/settings.py
@@ -186,7 +186,7 @@ EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 EMAIL_SECRET_KEY = os.environ.get("EMAIL_SECRET_KEY")
-EMAIL_INVITATION_BASE_URL = "http://localhost:3000/api/series"
+EMAIL_INVITATION_BASE_URL = "http://localhost:3000"
 
 # OTP settings
 OTP_EMAIL_HASH_KEY = os.environ.get("OTP_EMAIL_HASH_KEY", "")

--- a/hub/settings.py
+++ b/hub/settings.py
@@ -185,6 +185,8 @@ EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "admin@indiaultimate.org")
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
+EMAIL_SECRET_KEY = os.environ.get("EMAIL_SECRET_KEY")
+EMAIL_INVITATION_BASE_URL = "http://localhost:3000/api/series"
 
 # OTP settings
 OTP_EMAIL_HASH_KEY = os.environ.get("OTP_EMAIL_HASH_KEY", "")

--- a/hub/settings.py
+++ b/hub/settings.py
@@ -186,7 +186,11 @@ EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 EMAIL_SECRET_KEY = os.environ.get("EMAIL_SECRET_KEY")
-EMAIL_INVITATION_BASE_URL = "http://localhost:3000"
+
+if DEBUG:
+    EMAIL_INVITATION_BASE_URL = f"http://localhost:{os.environ.get('WEBPACK_SERVER_PORT', 3000)}"
+else:
+    EMAIL_INVITATION_BASE_URL = "https://hub.indiaultimate.org"
 
 # OTP settings
 OTP_EMAIL_HASH_KEY = os.environ.get("OTP_EMAIL_HASH_KEY", "")

--- a/server/series/api.py
+++ b/server/series/api.py
@@ -293,7 +293,7 @@ def accept_series_invitation_via_mail(
     valid, invitation_id = get_details_from_invitation_token(token)
 
     if not valid:
-        return 400, {"message": "Invalid invitation link"}
+        return 400, {"message": "Invitation link is invalid"}
 
     try:
         invitation = SeriesRosterInvitation.objects.get(id=invitation_id)
@@ -311,6 +311,9 @@ def accept_series_invitation_via_mail(
             return 400, {
                 "message": f"You already accepted this invitation on {invitation.rsvp_date}"
             }
+        
+        case SeriesRosterInvitation.Status.REVOKED:
+            return 400, {"message": "This invitation has been revoked"}
 
         case SeriesRosterInvitation.Status.PENDING:
             series_registration, error = register_player(
@@ -344,7 +347,7 @@ def decline_series_invitation_via_mail(
     valid, invitation_id = get_details_from_invitation_token(token)
 
     if not valid:
-        return 400, {"message": "Invalid invitation link"}
+        return 400, {"message": "Invitation link is invalid"}
 
     try:
         invitation = SeriesRosterInvitation.objects.get(id=invitation_id)
@@ -362,6 +365,9 @@ def decline_series_invitation_via_mail(
             return 400, {
                 "message": f"You already declined this invitation on {invitation.rsvp_date}"
             }
+        
+        case SeriesRosterInvitation.Status.REVOKED:
+            return 400, {"message": "This invitation has been revoked"}
 
         case SeriesRosterInvitation.Status.PENDING:
             invitation.status = SeriesRosterInvitation.Status.DECLINED

--- a/server/series/api.py
+++ b/server/series/api.py
@@ -254,7 +254,7 @@ def send_series_invitation(
 
 @router.get(
     "/invitation/accept",
-    response={200: SeriesRegistrationSchema, 400: Response},
+    response={200: SeriesRosterInvitationSchema, 400: Response},
     auth=None,
 )
 def accept_series_invitation_via_mail(
@@ -299,7 +299,7 @@ def accept_series_invitation_via_mail(
             invitation.status = SeriesRosterInvitation.Status.ACCEPTED
             invitation.rsvp_date = today()
             invitation.save()
-            return 200, series_registration
+            return 200, invitation
 
     return 400, {"message": f"'{invitation.status}' is not a valid invitation status"}
 

--- a/server/series/api.py
+++ b/server/series/api.py
@@ -236,7 +236,7 @@ def send_series_invitation(
 
     invitation.save()
 
-    invitation_token = generate_invitation_token(to_player.id, invitation.id)
+    invitation_token = generate_invitation_token(invitation.id)
 
     accept_invitation_link = f"{settings.EMAIL_INVITATION_BASE_URL}/accept-invitation?token={invitation_token}"
     decline_invitation_link = f"{settings.EMAIL_INVITATION_BASE_URL}/decline-invitation?token={invitation_token}"

--- a/server/series/api.py
+++ b/server/series/api.py
@@ -24,10 +24,10 @@ from .schema import (
 from .utils import (
     can_invite_player_to_series_roster,
     can_register_player_to_series_roster,
+    generate_invitation_token,
+    get_details_from_invitation_token,
     register_player,
     send_invitation_email,
-    get_details_from_invitation_token,
-    generate_invitation_token,
 )
 
 router = Router()
@@ -238,16 +238,21 @@ def send_series_invitation(
 
     invitation_token = generate_invitation_token(invitation.id)
 
-    accept_invitation_link = f"{settings.EMAIL_INVITATION_BASE_URL}/invitation/accept?token={invitation_token}"
-    decline_invitation_link = f"{settings.EMAIL_INVITATION_BASE_URL}/invitation/decline?token={invitation_token}"
+    accept_invitation_link = (
+        f"{settings.EMAIL_INVITATION_BASE_URL}/invitation/accept?token={invitation_token}"
+    )
+    decline_invitation_link = (
+        f"{settings.EMAIL_INVITATION_BASE_URL}/invitation/decline?token={invitation_token}"
+    )
 
     send_invitation_email(
-        from_user=request.user, 
-        to_player=to_player, 
-        team=team, 
-        series=series, 
+        from_user=request.user,
+        to_player=to_player,
+        team=team,
+        series=series,
         accept_invitation_link=accept_invitation_link,
-        decline_invitation_link=decline_invitation_link)
+        decline_invitation_link=decline_invitation_link,
+    )
 
     return 200, invitation
 
@@ -258,9 +263,9 @@ def send_series_invitation(
     auth=None,
 )
 def accept_series_invitation_via_mail(
-    request, token: str,
+    request: HttpRequest,
+    token: str,
 ) -> tuple[int, SeriesRegistration | message_response]:
-
     valid, invitation_id = get_details_from_invitation_token(token)
 
     if not valid:
@@ -270,7 +275,7 @@ def accept_series_invitation_via_mail(
         invitation = SeriesRosterInvitation.objects.get(id=invitation_id)
     except SeriesRosterInvitation.DoesNotExist:
         return 400, {"messsage": "Invitation does not exist"}
-    
+
     match invitation.status:
         case SeriesRosterInvitation.Status.EXPIRED:
             return 400, {"message": "This invitation has expired 😔"}
@@ -282,7 +287,7 @@ def accept_series_invitation_via_mail(
             return 400, {
                 "message": f"You already accepted this invitation on {invitation.rsvp_date}"
             }
-        
+
         case SeriesRosterInvitation.Status.REVOKED:
             return 400, {"message": "This invitation has been revoked"}
 
@@ -310,9 +315,9 @@ def accept_series_invitation_via_mail(
     auth=None,
 )
 def decline_series_invitation_via_mail(
-    request, token: str,
+    request: HttpRequest,
+    token: str,
 ) -> tuple[int, SeriesRosterInvitation | message_response]:
-
     valid, invitation_id = get_details_from_invitation_token(token)
 
     if not valid:
@@ -322,7 +327,7 @@ def decline_series_invitation_via_mail(
         invitation = SeriesRosterInvitation.objects.get(id=invitation_id)
     except SeriesRosterInvitation.DoesNotExist:
         return 400, {"messsage": "Invitation does not exist"}
-    
+
     match invitation.status:
         case SeriesRosterInvitation.Status.EXPIRED:
             return 400, {"message": "This invitation has expired 😔"}
@@ -334,7 +339,7 @@ def decline_series_invitation_via_mail(
             return 400, {
                 "message": f"You already declined this invitation on {invitation.rsvp_date}"
             }
-        
+
         case SeriesRosterInvitation.Status.REVOKED:
             return 400, {"message": "This invitation has been revoked"}
 

--- a/server/series/utils.py
+++ b/server/series/utils.py
@@ -164,9 +164,7 @@ def get_details_from_invitation_token(
         mail_secret_key = settings.EMAIL_SECRET_KEY
         payload = jwt.decode(token, mail_secret_key, algorithms=["HS256"])
 
-        return True, (
-            payload["invitation_id"],
-        )
+        return True, payload["invitation_id"]
     except jwt.InvalidTokenError:
         return False, None
 

--- a/server/series/utils.py
+++ b/server/series/utils.py
@@ -1,5 +1,4 @@
 import jwt
-
 from django.conf import settings
 from django.core import mail
 from django.template.loader import render_to_string
@@ -8,8 +7,6 @@ from django.utils.html import strip_tags
 from server.core.models import Player, Team, User
 from server.membership.models import Membership
 from server.types import message_response
-
-from typing import Optional
 
 from .models import Series, SeriesRegistration, SeriesRosterInvitation
 
@@ -145,9 +142,8 @@ def register_player(
 
     return SeriesRegistration.objects.create(series=series, team=team, player=player), None
 
-def generate_invitation_token(
-    invitation_id: int
-) -> str:
+
+def generate_invitation_token(invitation_id: int) -> str:
     mail_secret_key = settings.EMAIL_SECRET_KEY
 
     payload = {
@@ -157,9 +153,8 @@ def generate_invitation_token(
     token = jwt.encode(payload, mail_secret_key, algorithm="HS256")
     return token
 
-def get_details_from_invitation_token(
-    token: str
-) -> tuple[bool, Optional[int]]:
+
+def get_details_from_invitation_token(token: str) -> tuple[bool, int | str]:
     try:
         mail_secret_key = settings.EMAIL_SECRET_KEY
         payload = jwt.decode(token, mail_secret_key, algorithms=["HS256"])
@@ -167,14 +162,20 @@ def get_details_from_invitation_token(
         if "invitation_id" in payload:
             return True, payload["invitation_id"]
         else:
-            return False, None
-        
+            return False, "None"
+
     except jwt.InvalidTokenError:
-        return False, None
+        return False, "None"
 
 
 def send_invitation_email(
-    from_user: User, to_player: Player, team: Team, series: Series, accept_invitation_link : str, decline_invitation_link) -> None:
+    from_user: User,
+    to_player: Player,
+    team: Team,
+    series: Series,
+    accept_invitation_link: str,
+    decline_invitation_link: str,
+) -> None:
     subject = f"Hub | Invitation to join {team.name}'s roster"
 
     html_message = render_to_string(

--- a/server/series/utils.py
+++ b/server/series/utils.py
@@ -164,7 +164,11 @@ def get_details_from_invitation_token(
         mail_secret_key = settings.EMAIL_SECRET_KEY
         payload = jwt.decode(token, mail_secret_key, algorithms=["HS256"])
 
-        return True, payload["invitation_id"]
+        if "invitation_id" in payload:
+            return True, payload["invitation_id"]
+        else:
+            return False, None
+        
     except jwt.InvalidTokenError:
         return False, None
 

--- a/server/templates/series_roster_invitation_email.html
+++ b/server/templates/series_roster_invitation_email.html
@@ -28,10 +28,16 @@
                       <p>From: <strong>{{ from_name }}</strong></p>
                       <p>Team: <strong>{{ team_name }}</strong></p>
                       <p style="padding-bottom: 16px">Series: <strong>{{ series_name }}</strong></p>
-                      <p style="padding-bottom: 16px">
-                        <a href="{{ accept_invitation_link }}" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-align: center; text-decoration: none; display: inline-block; margin-right: 10px;">Accept Invitation</a>
-                        <a href="{{ decline_invitation_link }}" style="background-color: #f44336; color: white; padding: 10px 20px; text-align: center; text-decoration: none; display: inline-block;">Decline Invitation</a>
-                      </p>
+                      <table role="presentation" style="width: 60%; border-collapse: collapse; border: 0px; border-spacing: 0px;">
+                        <tr>
+                          <td style="padding: 5px; text-align: right;">
+                            <a href="{{ accept_invitation_link }}" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-align: center; text-decoration: none; display: inline-block;">Accept Invitation</a>
+                          </td>
+                          <td style="padding: 5px; text-align: left;">
+                            <a href="{{ decline_invitation_link }}" style="background-color: #f44336; color: white; padding: 10px 20px; text-align: center; text-decoration: none; display: inline-block;">Decline Invitation</a>
+                          </td>
+                        </tr>
+                      </table>
                       <p style="padding-bottom: 16px">You can also accept this invite by, 
                         <ul><li>Log into Hub with your account.</li><br /><li>Visit the <a href="https://hub.indiaultimate.org/series" target="_blank">series page</a> and click on accept this invitation.</li></ul>
                     </p>

--- a/server/templates/series_roster_invitation_email.html
+++ b/server/templates/series_roster_invitation_email.html
@@ -28,7 +28,11 @@
                       <p>From: <strong>{{ from_name }}</strong></p>
                       <p>Team: <strong>{{ team_name }}</strong></p>
                       <p style="padding-bottom: 16px">Series: <strong>{{ series_name }}</strong></p>
-                      <p style="padding-bottom: 16px">You can accept this invite by, 
+                      <p style="padding-bottom: 16px">
+                        <a href="{{ accept_invitation_link }}" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-align: center; text-decoration: none; display: inline-block; margin-right: 10px;">Accept Invitation</a>
+                        <a href="{{ decline_invitation_link }}" style="background-color: #f44336; color: white; padding: 10px 20px; text-align: center; text-decoration: none; display: inline-block;">Decline Invitation</a>
+                      </p>
+                      <p style="padding-bottom: 16px">You can also accept this invite by, 
                         <ul><li>Log into Hub with your account.</li><br /><li>Visit the <a href="https://hub.indiaultimate.org/series" target="_blank">series page</a> and click on accept this invitation.</li></ul>
                     </p>
                       <p style="padding-bottom: 16px">Thanks,<br>Your India Ultimate Hub Team</p>


### PR DESCRIPTION
#### On Team Admin side
- Encode invitation id and a key to a jwt
- Create accept and decline links & corresponding buttons in email template & send email.

#### On Player side
- Redirect to page, get the token and send call to backend to verify it.
- Get invitation id and follow the same procedure as before.

#### To test
- Set a `EMAIL_SECRET_KEY` environment variable.

#### Email ss
https://imgur.com/a/jj5QcC5

#### Series invitation error response UI
<img src="https://github.com/user-attachments/assets/bd9823b3-a24d-47af-b69b-0fde44bd3bea" width="500">

#### Series invitation accept UI
<img src="https://github.com/user-attachments/assets/87b63056-035e-4d9d-adc7-a13871b06f27" width="500">

#### Series invitation decline UI
<img src="https://github.com/user-attachments/assets/1682fbfc-6c54-42ad-a75f-fc70ee5c30a3" width="500">

