### PR TITLE
Team name edit

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -30,6 +30,7 @@ const ValidateRoster = lazy(() => import("./ValidateRoster"));
 const ValidateTransactions = lazy(() => import("./ValidateTransactions"));
 const Teams = lazy(() => import("./Teams"));
 const ViewTeam = lazy(() => import("./teams/View"));
+const EditTeam = lazy(() => import("./teams/Edit"));
 const CreateTeam = lazy(() => import("./teams/Create"));
 const TournamentManager = lazy(() => import("./TournamentManager"));
 const Tournaments = lazy(() => import("./Tournaments"));
@@ -133,6 +134,7 @@ export default function App() {
                   <Route path={"/team/:slug"} component={ViewTeam} />
                   {/* Team Private Routes */}
                   <UserRoute path="/teams/new" component={CreateTeam} />
+                  <UserRoute path="/team/:slug/edit" component={EditTeam} />
                   {/* Roster Public Route */}
                   <Route
                     path={"/tournament/:tournament_slug/team/:team_slug/roster"}

--- a/frontend/src/components/teams/Edit.js
+++ b/frontend/src/components/teams/Edit.js
@@ -4,12 +4,16 @@ import {
   required,
   setValues
 } from "@modular-forms/solid";
+import { useParams } from "@solidjs/router";
+import { createQuery } from "@tanstack/solid-query";
 import { createMutation, useQueryClient } from "@tanstack/solid-query";
 import { createAsyncOptions, Select } from "@thisbeyond/solid-select";
+import { userGroup } from "solid-heroicons/solid";
 import { createEffect, createSignal, Show } from "solid-js";
 
 import { stateChoices, teamCategoryChoices } from "../../constants";
-import { searchUsers, updateTeam } from "../../queries";
+import { fetchTeamBySlug, searchUsers, updateTeam } from "../../queries";
+import Breadcrumbs from "../Breadcrumbs";
 import FileInput from "../FileInput";
 import InputError from "../InputError";
 import InputLabel from "../InputLabel";
@@ -17,9 +21,18 @@ import DefaultSelect from "../Select";
 import TextInput from "../TextInput";
 
 const Edit = props => {
+  const params = useParams();
+
+  const [teamData, setTeamData] = createSignal();
+
   const [status, setStatus] = createSignal("");
   const [error, setError] = createSignal("");
   const [selectedValues, setSelectedValues] = createSignal();
+
+  const teamQuery = createQuery(
+    () => ["teams", params.slug],
+    () => fetchTeamBySlug(params.slug)
+  );
 
   const initialValues = {};
   const [updateTeamForm, { Form, Field }] = createForm({
@@ -29,8 +42,11 @@ const Edit = props => {
   });
 
   createEffect(() => {
-    setValues(updateTeamForm, props.teamData);
-    setSelectedValues([...props.teamData.admins]);
+    if (teamQuery.status === "success" && teamQuery.data) {
+      setTeamData(teamQuery.data);
+      setValues(updateTeamForm, teamData());
+      setSelectedValues([...teamData().admins]);
+    }
   });
 
   const onChange = selected => {
@@ -57,7 +73,7 @@ const Edit = props => {
   const handleSubmit = async values => {
     const { image, ...teamData } = values;
     const data = { ...teamData };
-    data.id = props.teamData.id;
+    data.id = teamQuery.data?.id;
 
     if (selectedValues() && selectedValues().length > 0) {
       data["admin_ids"] = selectedValues().map(value => value.id);
@@ -75,111 +91,137 @@ const Edit = props => {
 
   return (
     <div>
-      <Form class="space-y-2 md:space-y-4 lg:space-y-6" onSubmit={handleSubmit}>
-        <Field name="category" validate={required("Please select a category.")}>
-          {(field, props) => (
-            <DefaultSelect
-              {...props}
-              value={field.value}
-              options={teamCategoryChoices}
-              error={field.error}
-              label="Category"
-              placeholder="Select your team's category"
-              required
+      <Breadcrumbs
+        icon={userGroup}
+        pageList={[{ url: "/teams", name: "Teams" }, { name: "Edit Team" }]}
+      />
+      <div class="mx-2">
+        <div class="mb-6 flex w-full flex-row items-center justify-start gap-x-6 rounded-xl border border-gray-300 bg-gray-100 p-4">
+          <div>
+            <img
+              class="h-24 w-24 rounded-full p-1 ring-2 ring-gray-300 dark:ring-blue-500"
+              src={teamQuery.data?.image ?? teamQuery.data?.image_url}
+              alt="Bordered avatar"
             />
-          )}
-        </Field>
-        <Field
-          name="state_ut"
-          validate={required("Please select a State or UT.")}
-        >
-          {(field, props) => (
-            <DefaultSelect
-              {...props}
-              value={field.value}
-              options={stateChoices}
-              error={field.error}
-              label="Which State/UT team is based in?"
-              placeholder="Select State/UT"
-              required
-            />
-          )}
-        </Field>
-        <Field name="city" validate={required("Please enter the city name.")}>
-          {(field, props) => (
-            <TextInput
-              {...props}
-              value={field.value}
-              error={field.error}
-              type="text"
-              label="Which City team is based in?"
-              placeholder="Enter city name"
-              required
-            />
-          )}
-        </Field>
-        <Field
-          name="image"
-          type="File"
-          validate={
-            getValue(updateTeamForm, "image")
-              ? null
-              : required("Please add your team's logo.")
-          }
-        >
-          {(field, props) => (
-            <FileInput
-              {...props}
-              accept={"image/*"}
-              value={field.value}
-              error={field.error}
-              label="Upload Team Logo (Square Image Only)"
-              subLabel="Note: Uploading directly from Google Drive is not supported. Please download to device and upload as a file."
-              required={getValue(updateTeamForm, "image") ? false : true}
-            />
-          )}
-        </Field>
-        <div class="px-8 lg:px-10">
-          <InputLabel
-            name="admins"
-            label="Select the admins"
-            subLabel="Search by name or email"
-            required={true}
-          />
-          <Select
-            name="admins"
-            multiple
-            format={selectFormat}
-            onChange={onChange}
-            initialValue={selectedValues()}
-            isOptionDisabled={value =>
-              selectedValues()
-                .map(user => user.id)
-                .includes(value.id)
-            }
-            {...selectProps}
-          />
-          <InputError name="admins" error={""} />
+          </div>
+          <div class="text-lg font-bold text-gray-700">
+            {teamQuery.data?.name}
+          </div>
         </div>
-
-        <div class="flex w-full justify-center">
-          <button
-            type="submit"
-            class="w-full rounded-lg bg-blue-700 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-800 focus:outline-none focus:ring-4 focus:ring-blue-300 disabled:bg-gray-400 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 md:w-auto"
-            disabled={updateTeamMutation.isLoading}
+      </div>
+      <div class="mt-6">
+        <Form
+          class="space-y-2 md:space-y-4 lg:space-y-6"
+          onSubmit={handleSubmit}
+        >
+          <Field
+            name="category"
+            validate={required("Please select a category.")}
           >
-            <Show when={updateTeamMutation.isLoading} fallback="Update">
-              Updating...
-            </Show>
-          </button>
-        </div>
-      </Form>
-      <Show when={error()}>
-        <p class="my-2 text-sm text-red-600 dark:text-red-500">
-          <span class="font-medium">Oops!</span> {error()}
-        </p>
-      </Show>
-      <p>{status()}</p>
+            {(field, props) => (
+              <DefaultSelect
+                {...props}
+                value={field.value}
+                options={teamCategoryChoices}
+                error={field.error}
+                label="Category"
+                placeholder="Select your team's category"
+                required
+              />
+            )}
+          </Field>
+          <Field
+            name="state_ut"
+            validate={required("Please select a State or UT.")}
+          >
+            {(field, props) => (
+              <DefaultSelect
+                {...props}
+                value={field.value}
+                options={stateChoices}
+                error={field.error}
+                label="Which State/UT team is based in?"
+                placeholder="Select State/UT"
+                required
+              />
+            )}
+          </Field>
+          <Field name="city" validate={required("Please enter the city name.")}>
+            {(field, props) => (
+              <TextInput
+                {...props}
+                value={field.value}
+                error={field.error}
+                type="text"
+                label="Which City team is based in?"
+                placeholder="Enter city name"
+                required
+              />
+            )}
+          </Field>
+          <Field
+            name="image"
+            type="File"
+            validate={
+              getValue(updateTeamForm, "image")
+                ? null
+                : required("Please add your team's logo.")
+            }
+          >
+            {(field, props) => (
+              <FileInput
+                {...props}
+                accept={"image/*"}
+                value={field.value}
+                error={field.error}
+                label="Upload Team Logo (Square Image Only)"
+                subLabel="Note: Uploading directly from Google Drive is not supported. Please download to device and upload as a file."
+                required={getValue(updateTeamForm, "image") ? false : true}
+              />
+            )}
+          </Field>
+          <div class="px-8 lg:px-10">
+            <InputLabel
+              name="admins"
+              label="Select the admins"
+              subLabel="Search by name or email"
+              required={true}
+            />
+            <Select
+              name="admins"
+              multiple
+              format={selectFormat}
+              onChange={onChange}
+              initialValue={selectedValues()}
+              isOptionDisabled={value =>
+                selectedValues()
+                  .map(user => user.id)
+                  .includes(value.id)
+              }
+              {...selectProps}
+            />
+            <InputError name="admins" error={""} />
+          </div>
+
+          <div class="flex w-full justify-center">
+            <button
+              type="submit"
+              class="w-full rounded-lg bg-blue-700 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-800 focus:outline-none focus:ring-4 focus:ring-blue-300 disabled:bg-gray-400 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 md:w-auto"
+              disabled={updateTeamMutation.isLoading}
+            >
+              <Show when={updateTeamMutation.isLoading} fallback="Update">
+                Updating...
+              </Show>
+            </button>
+          </div>
+        </Form>
+        <Show when={error()}>
+          <p class="my-2 text-sm text-red-600 dark:text-red-500">
+            <span class="font-medium">Oops!</span> {error()}
+          </p>
+        </Show>
+        <p>{status()}</p>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/teams/Edit.js
+++ b/frontend/src/components/teams/Edit.js
@@ -20,7 +20,7 @@ import InputLabel from "../InputLabel";
 import DefaultSelect from "../Select";
 import TextInput from "../TextInput";
 
-const Edit = props => {
+const Edit = () => {
   const params = useParams();
 
   const [teamData, setTeamData] = createSignal();

--- a/frontend/src/components/teams/EditTeamNameForm.js
+++ b/frontend/src/components/teams/EditTeamNameForm.js
@@ -1,0 +1,83 @@
+import { createSignal } from "solid-js";
+import Error from "../alerts/Error";
+import Info from "../alerts/Info";
+import Warning from "../alerts/Warning";
+import TextInput from "../TextInput";
+import {
+  createForm,
+  getValue,
+  required,
+  toTrimmed
+} from "@modular-forms/solid";
+
+const EditTeamNameForm = props => {
+  const [status, setStatus] = createSignal("");
+  const [error, setError] = createSignal("");
+
+  const [editNameForm, { Form, Field }] = createForm({
+    initialValues: {
+      name: props.teamName
+    },
+    validateOn: "touched",
+    revalidateOn: "touched"
+  });
+
+  function handleSubmit(values) {
+    console.log(values);
+  }
+
+  function editedTeamName() {
+    // returns undefined if the team name is not edited
+    return getValue(editNameForm, "name", {
+      shouldDirty: true
+    });
+  }
+
+  return (
+    <>
+      <Warning>
+        The new team name will be shown in all past and future tournaments
+      </Warning>
+      <Form class="my-2" onSubmit={handleSubmit} shouldDirty={true}>
+        <div class="space-y-4">
+          <Field
+            name="name"
+            type="string"
+            transform={toTrimmed({ on: "input" })}
+            validate={required("Please enter a team name")}
+          >
+            {(field, fieldProps) => (
+              <TextInput
+                {...fieldProps}
+                type="text"
+                label="Team name"
+                placeholder="Team name"
+                value={field.value}
+                error={field.error}
+                required
+                padding
+              />
+            )}
+          </Field>
+          <button
+            type="submit"
+            disabled={editedTeamName() === undefined}
+            class="mb-2 w-full rounded-lg bg-blue-700 px-5 py-2.5 text-center text-sm font-medium text-white transition-all hover:bg-blue-800 focus:outline-none focus:ring-4 focus:ring-blue-300 disabled:bg-gray-400 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 sm:w-auto"
+          >
+            <Show when={editedTeamName()} fallback={"Submit"}>
+              Change name to {editedTeamName()}
+            </Show>
+          </button>
+          <Show when={error()}>
+            <Error text={`Oops ! ${error()}`} />
+          </Show>
+          <Show when={status()}>
+            <Info text={status()} />
+          </Show>
+        </div>
+      </Form>
+    </>
+  );
+};
+
+export default EditTeamNameForm;

--- a/frontend/src/components/teams/View.js
+++ b/frontend/src/components/teams/View.js
@@ -5,6 +5,30 @@ import { Show } from "solid-js";
 
 import { fetchTeamBySlug, fetchUser } from "../../queries";
 import Breadcrumbs from "../Breadcrumbs";
+import Modal from "../Modal";
+import EditTeamNameForm from "./EditTeamNameForm";
+
+const EditNameModal = props => {
+  let modalRef;
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => modalRef.showModal()}
+        class="inline-flex items-center gap-x-2 rounded-lg border-2 border-yellow-300 bg-yellow-50 px-3 py-2 text-center text-sm font-medium text-yellow-700 shadow-sm hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-yellow-300"
+      >
+        Edit name
+      </button>
+      <Modal
+        ref={modalRef}
+        title={<span class="text-md font-semibold">Edit name</span>}
+        close={() => modalRef.close()}
+      >
+        {props.children}
+      </Modal>
+    </>
+  );
+};
 
 const View = () => {
   const params = useParams();
@@ -45,12 +69,9 @@ const View = () => {
               }
             >
               <div class="flex flex-row gap-x-2">
-                <button
-                  type="button"
-                  class="inline-flex items-center gap-x-2 rounded-lg border-2 border-yellow-300 bg-yellow-50 px-3 py-2 text-center text-sm font-medium text-yellow-700 shadow-sm hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-yellow-300"
-                >
-                  Edit name
-                </button>
+                <EditNameModal>
+                  <EditTeamNameForm teamName={teamQuery.data?.name} />
+                </EditNameModal>
                 <A href={`/team/${params.slug}/edit`}>
                   <button
                     type="button"

--- a/frontend/src/components/teams/View.js
+++ b/frontend/src/components/teams/View.js
@@ -70,7 +70,10 @@ const View = () => {
             >
               <div class="flex flex-row gap-x-2">
                 <EditNameModal>
-                  <EditTeamNameForm teamName={teamQuery.data?.name} />
+                  <EditTeamNameForm
+                    teamId={teamQuery.data?.id}
+                    teamName={teamQuery.data?.name}
+                  />
                 </EditNameModal>
                 <A href={`/team/${params.slug}/edit`}>
                   <button

--- a/frontend/src/components/teams/View.js
+++ b/frontend/src/components/teams/View.js
@@ -1,27 +1,19 @@
-import { useParams } from "@solidjs/router";
+import { A, useParams } from "@solidjs/router";
 import { createQuery } from "@tanstack/solid-query";
 import { userGroup } from "solid-heroicons/solid";
-import { createEffect, createSignal, Show, Suspense } from "solid-js";
+import { Show } from "solid-js";
 
 import { fetchTeamBySlug, fetchUser } from "../../queries";
 import Breadcrumbs from "../Breadcrumbs";
-import Edit from "./Edit";
 
 const View = () => {
   const params = useParams();
-  const [teamData, setTeamData] = createSignal();
 
   const teamQuery = createQuery(
     () => ["teams", params.slug],
     () => fetchTeamBySlug(params.slug)
   );
   const userQuery = createQuery(() => ["me"], fetchUser);
-
-  createEffect(() => {
-    if (teamQuery.status === "success" && teamQuery.data) {
-      setTeamData(teamQuery.data);
-    }
-  });
 
   return (
     <div>
@@ -30,73 +22,83 @@ const View = () => {
         pageList={[{ url: "/teams", name: "Teams" }, { name: "View Team" }]}
       />
 
-      <div class="flex justify-center">
-        <img
-          class="mr-3 inline-block h-24 w-24 rounded-full p-1 ring-2 ring-gray-300 dark:ring-blue-500"
-          src={teamQuery.data?.image ?? teamQuery.data?.image_url}
-          alt="Bordered avatar"
-        />
-      </div>
-      <h1 class="my-5 text-center">
-        <span class="w-fit bg-gradient-to-r from-blue-500 to-green-500 bg-clip-text text-2xl font-extrabold text-transparent">
-          <Suspense
-            fallback={
-              <span class="inline-block h-2 w-60 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
-            }
-          >
-            {teamQuery.data?.name}
-          </Suspense>
-        </span>
-      </h1>
+      <div>
+        <div class="mb-6 flex w-full flex-row items-center justify-start gap-x-6 rounded-xl border border-gray-200 bg-gray-100 p-4">
+          <div>
+            <img
+              class="h-24 w-24 rounded-full p-1 ring-2 ring-gray-300 dark:ring-blue-500"
+              src={teamQuery.data?.image ?? teamQuery.data?.image_url}
+              alt="Bordered avatar"
+            />
+          </div>
 
-      <Show
-        when={
-          userQuery.isSuccess &&
-          userQuery.data?.admin_teams
-            ?.map(team => team.id)
-            .includes(teamQuery.data?.id)
-        }
-        fallback={
-          <dl class="max-w-md divide-y divide-gray-200 text-gray-900 dark:divide-gray-700 dark:text-white">
-            <div class="flex flex-col pb-3">
-              <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
-                Category
-              </dt>
-              <dd class="text-lg font-semibold">
-                {teamQuery.data?.category || "-"}
-              </dd>
+          <div class="flex flex-col items-start justify-center gap-y-2">
+            <div class="text-lg font-bold text-gray-700">
+              {teamQuery.data?.name}
             </div>
-            <div class="flex flex-col py-3">
-              <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
-                State
-              </dt>
-              <dd class="text-lg font-semibold">
-                {teamQuery.data?.state_ut || "-"}
-              </dd>
-            </div>
-            <div class="flex flex-col pt-3">
-              <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
-                City
-              </dt>
-              <dd class="text-lg font-semibold">
-                {teamQuery.data?.city || "-"}
-              </dd>
-            </div>
-            <div class="flex flex-col pt-3">
-              <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
-                Admins
-              </dt>
-              <dd class="text-lg font-semibold">
-                {teamQuery.data?.admins
-                  .map(admin => admin.full_name + ` (${admin.username})`)
-                  .join("\n") || "-"}
-              </dd>
-            </div>
-          </dl>
-        }
-      >
-        <Edit teamData={teamData()} />
-      </Show>
+            <Show
+              when={
+                userQuery.isSuccess &&
+                userQuery.data?.admin_teams
+                  ?.map(team => team.id)
+                  .includes(teamQuery.data?.id)
+              }
+            >
+              <div class="flex flex-row gap-x-2">
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-x-2 rounded-lg border-2 border-yellow-300 bg-yellow-50 px-3 py-2 text-center text-sm font-medium text-yellow-700 shadow-sm hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-yellow-300"
+                >
+                  Edit name
+                </button>
+                <A href={`/team/${params.slug}/edit`}>
+                  <button
+                    type="button"
+                    class="inline-flex items-center gap-x-2 rounded-lg border-2 border-yellow-300 bg-yellow-50 px-3 py-2 text-center text-sm font-medium text-yellow-700 shadow-sm hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-yellow-300"
+                  >
+                    Edit details
+                  </button>
+                </A>
+              </div>
+            </Show>
+          </div>
+        </div>
+
+        <dl class="mx-2 max-w-md divide-y divide-gray-200 text-gray-800 dark:divide-gray-700 dark:text-white">
+          <div class="flex flex-col pb-3">
+            <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
+              Category
+            </dt>
+            <dd class="text-lg font-semibold">
+              {teamQuery.data?.category || "-"}
+            </dd>
+          </div>
+          <div class="flex flex-col py-3">
+            <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
+              State
+            </dt>
+            <dd class="text-lg font-semibold">
+              {teamQuery.data?.state_ut || "-"}
+            </dd>
+          </div>
+          <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
+              City
+            </dt>
+            <dd class="text-lg font-semibold">{teamQuery.data?.city || "-"}</dd>
+          </div>
+          <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
+              Admins
+            </dt>
+            <dd class="text-lg font-semibold">
+              {teamQuery.data?.admins
+                .map(admin => admin.full_name + ` (${admin.username})`)
+                .join("\n") || "-"}
+            </dd>
+          </div>
+        </dl>
+      </div>
     </div>
   );
 };

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -1,4 +1,4 @@
-import { delay, getCookie } from "./utils";
+import { getCookie } from "./utils";
 
 export const fetchContributors = async () => {
   const repoResp = await fetch(
@@ -1349,8 +1349,6 @@ export const createMatchStatsEvent = async ({ match_id, body }) => {
 
   const data = await response.json();
 
-  await delay(800);
-
   if (!response.ok) {
     throw new Error(data?.message || JSON.stringify(data));
   }
@@ -1369,8 +1367,6 @@ export const matchStatsSwitchOffense = async ({ match_id }) => {
   });
 
   const data = await response.json();
-
-  await delay(500);
 
   if (!response.ok) {
     throw new Error(data?.message || JSON.stringify(data));

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -1256,6 +1256,25 @@ export const createTeam = async formData => {
   return data;
 };
 
+export const updateTeamName = async body => {
+  const response = await fetch("/api/teams/edit-name", {
+    method: "PUT",
+    headers: {
+      "X-CSRFToken": getCookie("csrftoken")
+    },
+    credentials: "same-origin",
+    body: JSON.stringify(body)
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data?.message || JSON.stringify(data));
+  }
+
+  return data;
+};
+
 export const updateTeam = async formData => {
   const response = await fetch("/api/teams/edit", {
     method: "POST",

--- a/server/schema.py
+++ b/server/schema.py
@@ -137,6 +137,11 @@ class TeamCreateSchema(Schema):
     city: str
 
 
+class TeamNameUpdateSchema(Schema):
+    id: str
+    name: str
+
+
 class TeamUpdateSchema(Schema):
     id: str
     category: str | None


### PR DESCRIPTION
First i thought of adding team name as a field in the team edit form, but the team name is more important than the other details. So i decided to split the name and keep the team edit form as is.

![image](https://github.com/user-attachments/assets/20d65656-1ddd-4be4-9ccb-99129801d8b0)

- [x]  Moved team editing to a new page
- [x] Team admins can see buttons to edit team name and edit team details. Edit name buttons is a modal, edit team button routes to the edit page
- [x] Add form to edit team name
- [x] Add api endpoint to edit team name