### PR TITLE
Include series teams in response

### DIFF
--- a/server/tournament/schema.py
+++ b/server/tournament/schema.py
@@ -10,7 +10,7 @@ from server.schema import (
     TeamMinSchema,
     TeamSchema,
 )
-from server.series.schema import SeriesMinSchema
+from server.series.schema import SeriesSchema
 
 from .models import (
     Bracket,
@@ -40,7 +40,7 @@ class UCRegistrationSchema(ModelSchema):
 
 
 class EventSchema(ModelSchema):
-    series: SeriesMinSchema | None
+    series: SeriesSchema | None
 
     class Config:
         model = Event
@@ -76,7 +76,9 @@ class TournamentSchema(ModelSchema):
         return [
             RegistrationCount(
                 team_id=team.id,
-                count=Registration.objects.filter(team=team, event=tournament.event).count(),
+                count=Registration.objects.filter(
+                    team=team, event=tournament.event
+                ).count(),
             )
             for team in teams
         ]


### PR DESCRIPTION
In the team registration page, we check whether the team is part of the series before registration.

In https://github.com/india-ultimate/hub/commit/99816bce4b6f9b3b36aa532a02c917333404e3a2, we set the event schema to return series data without the teams. This breaks the registration flow, because there are no series teams to check against.

Reverting back to sending the series data with all the teams.

We need to add include/exclude filters to our APIs, to avoid this. Can pick this up