### PR TITLE
vm: Scale

### DIFF
--- a/deploy/start.sh
+++ b/deploy/start.sh
@@ -22,4 +22,4 @@ tmux new-session -d -s hub-worker "python manage.py run_task_worker --sleep-seco
 
 # Start the server using gunicorn
 export PATH="$HOME/.local/bin:$PATH"
-gunicorn -w 4 hub.wsgi
+gunicorn -w 12 hub.wsgi

--- a/fly.toml
+++ b/fly.toml
@@ -23,7 +23,7 @@ swap_size_mb = 512
   DJANGO_SETTINGS_MODULE = "hub.production"
 
 [[vm]]
-  size = "shared-cpu-2x"
+  size = "shared-cpu-8x"
 
 [[services]]
   protocol = "tcp"
@@ -40,8 +40,8 @@ swap_size_mb = 512
     handlers = ["tls", "http"]
   [services.concurrency]
     type = "connections"
-    hard_limit = 100
-    soft_limit = 75
+    hard_limit = 400
+    soft_limit = 300
 
   [[services.tcp_checks]]
     interval = "15s"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase VM size, gunicorn workers, and Fly.io service concurrency limits to scale capacity.
> 
> - **Infrastructure / Deployment**:
>   - **Fly.io config (`fly.toml`)**:
>     - Scale VM size: `[[vm]].size` from `shared-cpu-2x` to `shared-cpu-8x`.
>     - Raise concurrency limits: `hard_limit` 100→400, `soft_limit` 75→300 under `services.concurrency`.
> - **Runtime**:
>   - **Gunicorn**: Increase workers in `deploy/start.sh` from `-w 4` to `-w 12`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cfaa7892dc6d2a5032fdf1cbafbcf4421dba7ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->