### PR TITLE
vm: Scale

### DIFF
--- a/deploy/start.sh
+++ b/deploy/start.sh
@@ -22,4 +22,4 @@ tmux new-session -d -s hub-worker "python manage.py run_task_worker --sleep-seco
 
 # Start the server using gunicorn
 export PATH="$HOME/.local/bin:$PATH"
-gunicorn -w 12 hub.wsgi
+gunicorn -w 4 hub.wsgi

--- a/fly.toml
+++ b/fly.toml
@@ -23,7 +23,7 @@ swap_size_mb = 512
   DJANGO_SETTINGS_MODULE = "hub.production"
 
 [[vm]]
-  size = "shared-cpu-8x"
+  size = "shared-cpu-2x"
 
 [[services]]
   protocol = "tcp"
@@ -40,8 +40,8 @@ swap_size_mb = 512
     handlers = ["tls", "http"]
   [services.concurrency]
     type = "connections"
-    hard_limit = 400
-    soft_limit = 300
+    hard_limit = 100
+    soft_limit = 75
 
   [[services.tcp_checks]]
     interval = "15s"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Right-size deployment to lower resource usage.
> 
> - Decreases Gunicorn workers in `deploy/start.sh` from `12` to `4`
> - Scales Fly VM from `shared-cpu-8x` to `shared-cpu-2x` in `fly.toml`
> - Lowers Fly services concurrency limits from `400/300` to `100/75`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa8ac692bdd3fa313b451668f51b505ca07aa772. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->