### PR TITLE
wrapped: Add emojis and some edits

### DIFF
--- a/frontend/src/components/wrapped/Wrapped.js
+++ b/frontend/src/components/wrapped/Wrapped.js
@@ -47,7 +47,6 @@ const TournamentBestCard = props => {
 };
 
 const WrappedYearDisplay = props => {
-  // Temporary wrapped data for preview/demo
   const wrapped = () => props.wrapped;
   const player = () => props.player;
   const [isDownloading, setIsDownloading] = createSignal(false);
@@ -165,15 +164,15 @@ const WrappedYearDisplay = props => {
               {/* Tournament Bests */}
               <div class="mt-4 grid grid-cols-1 rounded-lg bg-blue-50 p-2 md:grid-cols-3">
                 <TournamentBestCard
-                  title="Peak Offensive Performance"
+                  title="⚡ Peak Offensive Performance"
                   data={wrapped()?.most_scores_in_tournament}
                 />
                 <TournamentBestCard
-                  title="Playmaking Masterclass"
+                  title="🎨 Playmaking Masterclass"
                   data={wrapped()?.most_assists_in_tournament}
                 />
                 <TournamentBestCard
-                  title="Defensive Brilliance"
+                  title="🚫 Disc Denial Expert"
                   data={wrapped()?.most_blocks_in_tournament}
                 />
               </div>
@@ -188,7 +187,7 @@ const WrappedYearDisplay = props => {
                 >
                   <div>
                     <h3 class="text-md text-left font-semibold text-black">
-                      My Favourite Targets 🎯
+                      🎯 My Favourite Targets
                     </h3>
                     <div class="mt-1 text-base">
                       <For
@@ -217,7 +216,7 @@ const WrappedYearDisplay = props => {
                 >
                   <div>
                     <h3 class="text-md text-left font-semibold text-black">
-                      They found me in space 🤝
+                      🙌 My Favorite Throwers
                     </h3>
                     <div class="mt-1 text-base">
                       <For


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Polishes the Wrapped UI text and visuals.
> 
> - Updates `TournamentBestCard` titles with emojis and new phrasing (e.g., `⚡ Peak Offensive Performance`, `🎨 Playmaking Masterclass`, `🚫 Disc Denial Expert`)
> - Revises Top Teammates section headers (emoji-first and copy tweaks: `🎯 My Favourite Targets`, `🙌 My Favorite Throwers`)
> - Removes a temporary comment from `WrappedYearDisplay`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 762a0ada24e20d89dc2ad94d3ef3efe781ac5d82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->