### PR TITLE
wrapped: Use modern screenshot library

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,7 @@
     "@tanstack/solid-table": "^8.19.2",
     "@thisbeyond/solid-dnd": "^0.7.4",
     "@thisbeyond/solid-select": "^0.14.0",
-    "html-to-image": "^1.11.13"
+    "modern-screenshot": "^4.6.7"
   },
   "prettier": {
     "trailingComma": "none",

--- a/frontend/src/components/wrapped/Wrapped.js
+++ b/frontend/src/components/wrapped/Wrapped.js
@@ -1,5 +1,5 @@
 import { createQuery } from "@tanstack/solid-query";
-import { toPng } from "html-to-image";
+import { domToPng } from "modern-screenshot";
 import { Icon } from "solid-heroicons";
 import { arrowDownTray, sparkles, trophy } from "solid-heroicons/solid";
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
@@ -58,10 +58,9 @@ const WrappedYearDisplay = props => {
 
     setIsDownloading(true);
     try {
-      const dataUrl = await toPng(cardRef, {
+      const dataUrl = await domToPng(cardRef, {
         quality: 1.0,
-        canvasWidth: 1080,
-        canvasHeight: 1890,
+        scale: 8,
         backgroundColor: "#ffffff"
       });
 
@@ -141,7 +140,7 @@ const WrappedYearDisplay = props => {
                 </span>
               </div>
 
-              <div class="mt-4 w-full rounded-lg bg-blue-50 p-2">
+              <div class="mt-2 w-full rounded-lg bg-blue-50 p-2">
                 <div class="grid grid-cols-4">
                   <StatCard label="Games" value={wrapped()?.total_games} />
                   <StatCard label="Scores" value={wrapped()?.total_scores} />
@@ -162,7 +161,7 @@ const WrappedYearDisplay = props => {
               </div>
 
               {/* Tournament Bests */}
-              <div class="mt-4 grid grid-cols-1 rounded-lg bg-blue-50 p-2 md:grid-cols-3">
+              <div class="mt-2 grid grid-cols-1 rounded-lg bg-blue-50 p-2 md:grid-cols-3">
                 <TournamentBestCard
                   title="⚡ Peak Offensive Performance"
                   data={wrapped()?.most_scores_in_tournament}
@@ -178,7 +177,7 @@ const WrappedYearDisplay = props => {
               </div>
 
               {/* Top Teammates */}
-              <div class="mt-4 grid grid-cols-2 gap-2 rounded-lg bg-blue-50 p-2">
+              <div class="mt-2 grid grid-cols-2 rounded-lg bg-blue-50 p-2">
                 <Show
                   when={
                     wrapped()?.top_teammates_i_assisted &&

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3124,11 +3124,6 @@ html-tags@^3.0.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.3.1.tgz#a04026a18c882e4bba8a01a3d39cfe465d40b5ce"
   integrity sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==
 
-html-to-image@^1.11.13:
-  version "1.11.13"
-  resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.11.13.tgz#adbc989c993b7aaf90b629c0cacf833db84d5f43"
-  integrity sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==
-
 html-webpack-plugin@^5.5.3:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.5.3.tgz#72270f4a78e222b5825b296e5e3e1328ad525a3e"
@@ -4183,6 +4178,11 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+modern-screenshot@^4.6.7:
+  version "4.6.7"
+  resolved "https://registry.yarnpkg.com/modern-screenshot/-/modern-screenshot-4.6.7.tgz#b130025a36dc50270017c6799a4d651e2d4525cd"
+  integrity sha512-0GhgI6i6le4AhKzCvLYjwEmsP47kTsX45iT5yuAzsLTi/7i3Rjxe8fbH2VjGJLuyOThwsa0CdQAPd4auoEtsZg==
 
 mri@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Switch to modern-screenshot for PNG export**
> 
> - Replace `html-to-image` with `modern-screenshot` in `package.json` and `yarn.lock`
> - Update `Wrapped.js` to use `domToPng` instead of `toPng`, removing fixed canvas dimensions and using `scale: 8` with `quality: 1.0` and white background
> - Minor UI tweaks: reduce top margins from `mt-4` to `mt-2` on stat and section containers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08a571c603f4a5b37cae336652403ecb77b00c3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->