### PR TITLE
Add tournament info on team page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can report issues on
 
 ## Development
 
-This project Poetry to manage the backend dependencies
+This project uses Poetry to manage the backend dependencies
 
 Follow the offical docs to [install Poetry](https://python-poetry.org/docs/#installing-with-pipx)
 
@@ -29,6 +29,12 @@ Install dependencies with Poetry
 
 ```bash
 poetry install
+```
+
+Install the poetry shell plugin
+
+```bash
+poetry self add poetry-plugin-shell
 ```
 
 Using the poetry virtual env
@@ -57,7 +63,7 @@ python manage.py runserver
 
 The frontend is built using SolidJS and Yarn.
 
-Prerequisites: Node v22 and npm. (Recommend using nvm to manage node versions!)
+Prerequisites: Node v22 and npm. (Recommend using [nvm](https://github.com/nvm-sh/nvm) to manage node versions!)
 
 Install Yarn following official documentations [here](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable).
 

--- a/frontend/src/components/Tournaments.js
+++ b/frontend/src/components/Tournaments.js
@@ -1,9 +1,8 @@
-import { A } from "@solidjs/router";
 import { createQuery } from "@tanstack/solid-query";
-import clsx from "clsx";
-import { createSignal, For, Match, Show, Switch } from "solid-js";
+import { createSignal, For } from "solid-js";
 
 import { fetchTournaments } from "../queries";
+import TournamentCard from "./tournament/TournamentCard";
 
 const Tournaments = () => {
   const tournamentsQuery = createQuery(() => ["tournaments"], fetchTournaments);
@@ -90,111 +89,7 @@ const Tournaments = () => {
             return false;
           })}
         >
-          {tournament => (
-            <Show when={tournament.status !== "DFT"}>
-              <A
-                href={
-                  tournament.status === "REG" || tournament.status === "SCH"
-                    ? `/tournament/${tournament.event?.slug}/register`
-                    : `/tournament/${tournament.event?.slug}`
-                }
-                class="block w-full rounded-lg border border-blue-600 bg-white p-4 shadow dark:border-blue-400 dark:bg-gray-800"
-              >
-                <Show when={tournament.event?.type}>
-                  <span class="mr-2 h-fit rounded bg-blue-200 px-2.5 py-0.5 text-sm font-medium text-blue-800 dark:bg-green-900 dark:text-green-300">
-                    <Switch>
-                      <Match when={tournament.event?.type === "MXD"}>
-                        Mixed
-                      </Match>
-                      <Match when={tournament.event?.type === "OPN"}>
-                        Opens
-                      </Match>
-                      <Match when={tournament.event?.type === "WMN"}>
-                        Womens
-                      </Match>
-                    </Switch>
-                  </span>
-                </Show>
-
-                <Switch>
-                  <Match when={tournament.status === "REG"}>
-                    <span class="h-fit rounded bg-green-200 px-2.5 py-0.5 text-sm font-medium text-green-800 dark:bg-green-900 dark:text-green-300">
-                      Registrations open
-                    </span>
-                  </Match>
-                  <Match when={tournament.status === "SCH"}>
-                    <span class="h-fit rounded bg-yellow-100 px-2.5 py-0.5 text-sm font-medium text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300">
-                      Registrations closed
-                    </span>
-                  </Match>
-                  <Match when={tournament.status === "LIV"}>
-                    <span
-                      class={clsx(
-                        "h-fit rounded px-2.5 py-0.5 text-sm font-medium",
-                        new Date(Date.now()) < Date.parse(tournament.start_date)
-                          ? "bg-blue-200 text-blue-800 dark:bg-blue-900 dark:text-blue-300"
-                          : "bg-red-200 text-red-800 dark:bg-red-900 dark:text-red-300"
-                      )}
-                    >
-                      {new Date(Date.now()) < Date.parse(tournament.start_date)
-                        ? "Upcoming"
-                        : "Live"}
-                    </span>
-                  </Match>
-                  <Match when={tournament.status === "COM"}>
-                    <span class="h-fit rounded bg-gray-300 px-2.5 py-0.5 text-sm font-medium text-gray-700 dark:bg-gray-900 dark:text-gray-300">
-                      Completed
-                    </span>
-                  </Match>
-                </Switch>
-                <div class="mb-2 mt-2">
-                  <h5 class="text-xl font-bold capitalize tracking-tight text-blue-600 dark:text-blue-400">
-                    {tournament.event.title}
-                  </h5>
-                  <Show when={tournament.event?.series}>
-                    <p class="text-sm italic">
-                      Part of{" "}
-                      <span class="text-blue-600">
-                        {tournament.event?.series?.name}
-                      </span>
-                    </p>
-                  </Show>
-                </div>
-
-                <div class="flex justify-between">
-                  <span class="flex-grow text-sm capitalize">
-                    {tournament.event.location}
-                  </span>
-                </div>
-                <p class="text-sm text-blue-600 dark:text-blue-400">
-                  {new Date(
-                    Date.parse(tournament.event.start_date)
-                  ).toLocaleDateString("en-US", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                    timeZone: "UTC"
-                  })}
-                  <Show
-                    when={
-                      tournament.event.start_date !== tournament.event.end_date
-                    }
-                  >
-                    {" "}
-                    to{" "}
-                    {new Date(
-                      Date.parse(tournament.event.end_date)
-                    ).toLocaleDateString("en-US", {
-                      year: "numeric",
-                      month: "short",
-                      day: "numeric",
-                      timeZone: "UTC"
-                    })}
-                  </Show>
-                </p>
-              </A>
-            </Show>
-          )}
+          {tournament => <TournamentCard tournament={tournament} />}
         </For>
       </div>
     </div>

--- a/frontend/src/components/teams/View.js
+++ b/frontend/src/components/teams/View.js
@@ -1,7 +1,7 @@
 import { A, useParams } from "@solidjs/router";
 import { createQuery } from "@tanstack/solid-query";
 import { userGroup } from "solid-heroicons/solid";
-import { Show } from "solid-js";
+import { For, Show } from "solid-js";
 
 import { fetchTeamBySlug, fetchUser } from "../../queries";
 import Breadcrumbs from "../Breadcrumbs";
@@ -88,7 +88,7 @@ const View = () => {
           </div>
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-y-6">
+        <div class="grid grid-cols-1 gap-y-6 md:grid-cols-2">
           <dl class="mx-2 max-w-md divide-y divide-gray-200 text-gray-800 dark:divide-gray-700 dark:text-white">
             <div class="flex flex-col pb-3">
               <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
@@ -110,15 +110,18 @@ const View = () => {
               <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
                 City
               </dt>
-              <dd class="text-lg font-semibold">{teamQuery.data?.city || "-"}</dd>
+              <dd class="text-lg font-semibold">
+                {teamQuery.data?.city || "-"}
+              </dd>
             </div>
             <div class="flex flex-col pt-3">
               <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
                 Admins
               </dt>
               <dd class="text-lg font-semibold">
-                {teamQuery.data?.admins
-                  .map(admin => (<p>{admin.full_name + ` (${admin.username})`}</p>)) || "-"}
+                {teamQuery.data?.admins.map(admin => (
+                  <p>{admin.full_name + ` (${admin.username})`}</p>
+                )) || "-"}
               </dd>
             </div>
           </dl>
@@ -130,38 +133,53 @@ const View = () => {
               <dd>
                 <div class="flex flex-col gap-y-3">
                   <Show
-                    when={teamQuery.data?.tournaments && teamQuery.data.tournaments.length > 0}
+                    when={
+                      teamQuery.data?.tournaments &&
+                      teamQuery.data.tournaments.length > 0
+                    }
                     fallback={<p class="text-gray-500">No tournaments</p>}
                   >
-                    {teamQuery.data?.tournaments.map(tournament => (
-                      <A
-                        href={`/tournament/${tournament.event.slug}/team/${params.slug}`}
-                        class="flex items-center gap-3 rounded-md bg-gray-100 p-3 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
-                      >
-                        <Show when={tournament.logo_light || tournament.logo_dark}>
-                          <img
-                            src={tournament.logo_dark || tournament.logo_light}
-                            alt="Tournament logo"
-                            class="hidden h-12 w-12 rounded-sm object-contain dark:block"
-                          />
-                          <img
-                            src={tournament.logo_light || tournament.logo_dark}
-                            alt="Tournament logo"
-                            class="block h-12 w-12 rounded-sm object-contain dark:hidden"
-                          />
-                        </Show>
-                        <div class="flex-1">
-                          <h3 class="text-sm font-bold text-gray-700 dark:text-white">
-                            {tournament.event.title}
-                          </h3>
-                          <Show when={tournament.current_seed}>
-                            <p class="mt-1 text-xs text-gray-600 dark:text-gray-400">
-                              Seed: {tournament.current_seed}
-                            </p>
-                          </Show>
-                        </div>
-                      </A>
-                    ))}
+                    {
+                      <For each={teamQuery.data?.tournaments}>
+                        {tournament => (
+                          <A
+                            href={`/tournament/${tournament.event.slug}/team/${params.slug}`}
+                            class="flex items-center gap-3 rounded-md bg-gray-100 p-3 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
+                          >
+                            <Show
+                              when={
+                                tournament.logo_light || tournament.logo_dark
+                              }
+                            >
+                              <img
+                                src={
+                                  tournament.logo_dark || tournament.logo_light
+                                }
+                                alt="Tournament logo"
+                                class="hidden h-12 w-12 rounded-sm object-contain dark:block"
+                              />
+                              <img
+                                src={
+                                  tournament.logo_light || tournament.logo_dark
+                                }
+                                alt="Tournament logo"
+                                class="block h-12 w-12 rounded-sm object-contain dark:hidden"
+                              />
+                            </Show>
+                            <div class="flex-1">
+                              <h3 class="text-sm font-bold text-gray-700 dark:text-white">
+                                {tournament.event.title}
+                              </h3>
+                              <Show when={tournament.current_seed}>
+                                <p class="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                                  Seed: {tournament.current_seed}
+                                </p>
+                              </Show>
+                            </div>
+                          </A>
+                        )}
+                      </For>
+                    }
                   </Show>
                 </div>
               </dd>

--- a/frontend/src/components/teams/View.js
+++ b/frontend/src/components/teams/View.js
@@ -3,9 +3,11 @@ import { createQuery } from "@tanstack/solid-query";
 import { userGroup } from "solid-heroicons/solid";
 import { For, Show } from "solid-js";
 
+import { ChevronRight } from "../../icons";
 import { fetchTeamBySlug, fetchUser } from "../../queries";
 import Breadcrumbs from "../Breadcrumbs";
 import Modal from "../Modal";
+import TournamentCard from "../tournament/TournamentCard";
 import EditTeamNameForm from "./EditTeamNameForm";
 
 const EditNameModal = props => {
@@ -22,6 +24,30 @@ const EditNameModal = props => {
       <Modal
         ref={modalRef}
         title={<span class="text-md font-semibold">Edit name</span>}
+        close={() => modalRef.close()}
+      >
+        {props.children}
+      </Modal>
+    </>
+  );
+};
+
+const AllTournamentsModal = props => {
+  let modalRef;
+  return (
+    <>
+      <A
+        href="#"
+        onclick={() => modalRef.showModal()}
+        class="text-sm text-blue-600 md:text-base"
+      >
+        <span class="inline-flex items-center">
+          View all <ChevronRight height={16} width={16} />
+        </span>
+      </A>
+      <Modal
+        ref={modalRef}
+        title={<span class="text-md font-semibold">All Tournaments</span>}
         close={() => modalRef.close()}
       >
         {props.children}
@@ -127,9 +153,42 @@ const View = () => {
           </dl>
           <dl class="mx-2 max-w-md divide-y divide-gray-200 text-gray-800 dark:divide-gray-700 dark:text-white">
             <div class="flex flex-col pb-3">
-              <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
-                Last Played Tournaments
-              </dt>
+              <div class="mb-3 flex items-center justify-between">
+                <dt class="text-gray-500 dark:text-gray-400 md:text-lg">
+                  Last Played Tournaments
+                </dt>
+                <Show
+                  when={
+                    teamQuery.data?.tournaments &&
+                    teamQuery.data.tournaments.length > 2
+                  }
+                >
+                  <AllTournamentsModal>
+                    <div class="flex flex-col gap-y-3">
+                      {
+                        <For each={teamQuery.data?.tournaments}>
+                          {tournament => (
+                            <TournamentCard tournament={tournament}>
+                              <div class="mt-2 flex justify-between font-bold">
+                                <Show when={tournament.current_seed}>
+                                  <span class="text-sm">
+                                    Current Seed: {tournament.current_seed}
+                                  </span>
+                                </Show>
+                                <Show when={tournament.spirit_ranking}>
+                                  <span class="text-sm">
+                                    SOTG Ranking: {tournament.spirit_ranking}
+                                  </span>
+                                </Show>
+                              </div>
+                            </TournamentCard>
+                          )}
+                        </For>
+                      }
+                    </div>
+                  </AllTournamentsModal>
+                </Show>
+              </div>
               <dd>
                 <div class="flex flex-col gap-y-3">
                   <Show
@@ -137,46 +196,25 @@ const View = () => {
                       teamQuery.data?.tournaments &&
                       teamQuery.data.tournaments.length > 0
                     }
-                    fallback={<p class="text-gray-500">No tournaments</p>}
+                    fallback={<p class="text-md">No tournaments played!</p>}
                   >
                     {
-                      <For each={teamQuery.data?.tournaments}>
+                      <For each={teamQuery.data?.tournaments.slice(0, 2)}>
                         {tournament => (
-                          <A
-                            href={`/tournament/${tournament.event.slug}/team/${params.slug}`}
-                            class="flex items-center gap-3 rounded-md bg-gray-100 p-3 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
-                          >
-                            <Show
-                              when={
-                                tournament.logo_light || tournament.logo_dark
-                              }
-                            >
-                              <img
-                                src={
-                                  tournament.logo_dark || tournament.logo_light
-                                }
-                                alt="Tournament logo"
-                                class="hidden h-12 w-12 rounded-sm object-contain dark:block"
-                              />
-                              <img
-                                src={
-                                  tournament.logo_light || tournament.logo_dark
-                                }
-                                alt="Tournament logo"
-                                class="block h-12 w-12 rounded-sm object-contain dark:hidden"
-                              />
-                            </Show>
-                            <div class="flex-1">
-                              <h3 class="text-sm font-bold text-gray-700 dark:text-white">
-                                {tournament.event.title}
-                              </h3>
+                          <TournamentCard tournament={tournament}>
+                            <div class="mt-2 flex justify-between font-bold">
                               <Show when={tournament.current_seed}>
-                                <p class="mt-1 text-xs text-gray-600 dark:text-gray-400">
-                                  Seed: {tournament.current_seed}
-                                </p>
+                                <span class="text-sm">
+                                  Current Seed: {tournament.current_seed}
+                                </span>
+                              </Show>
+                              <Show when={tournament.spirit_ranking}>
+                                <span class="text-sm">
+                                  SOTG Ranking: {tournament.spirit_ranking}
+                                </span>
                               </Show>
                             </div>
-                          </A>
+                          </TournamentCard>
                         )}
                       </For>
                     }

--- a/frontend/src/components/teams/View.js
+++ b/frontend/src/components/teams/View.js
@@ -88,40 +88,86 @@ const View = () => {
           </div>
         </div>
 
-        <dl class="mx-2 max-w-md divide-y divide-gray-200 text-gray-800 dark:divide-gray-700 dark:text-white">
-          <div class="flex flex-col pb-3">
-            <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
-              Category
-            </dt>
-            <dd class="text-lg font-semibold">
-              {teamQuery.data?.category || "-"}
-            </dd>
-          </div>
-          <div class="flex flex-col py-3">
-            <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
-              State
-            </dt>
-            <dd class="text-lg font-semibold">
-              {teamQuery.data?.state_ut || "-"}
-            </dd>
-          </div>
-          <div class="flex flex-col pt-3">
-            <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
-              City
-            </dt>
-            <dd class="text-lg font-semibold">{teamQuery.data?.city || "-"}</dd>
-          </div>
-          <div class="flex flex-col pt-3">
-            <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
-              Admins
-            </dt>
-            <dd class="text-lg font-semibold">
-              {teamQuery.data?.admins
-                .map(admin => admin.full_name + ` (${admin.username})`)
-                .join("\n") || "-"}
-            </dd>
-          </div>
-        </dl>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-y-6">
+          <dl class="mx-2 max-w-md divide-y divide-gray-200 text-gray-800 dark:divide-gray-700 dark:text-white">
+            <div class="flex flex-col pb-3">
+              <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
+                Category
+              </dt>
+              <dd class="text-lg font-semibold">
+                {teamQuery.data?.category || "-"}
+              </dd>
+            </div>
+            <div class="flex flex-col py-3">
+              <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
+                State
+              </dt>
+              <dd class="text-lg font-semibold">
+                {teamQuery.data?.state_ut || "-"}
+              </dd>
+            </div>
+            <div class="flex flex-col pt-3">
+              <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
+                City
+              </dt>
+              <dd class="text-lg font-semibold">{teamQuery.data?.city || "-"}</dd>
+            </div>
+            <div class="flex flex-col pt-3">
+              <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
+                Admins
+              </dt>
+              <dd class="text-lg font-semibold">
+                {teamQuery.data?.admins
+                  .map(admin => (<p>{admin.full_name + ` (${admin.username})`}</p>)) || "-"}
+              </dd>
+            </div>
+          </dl>
+          <dl class="mx-2 max-w-md divide-y divide-gray-200 text-gray-800 dark:divide-gray-700 dark:text-white">
+            <div class="flex flex-col pb-3">
+              <dt class="mb-1 text-gray-500 dark:text-gray-400 md:text-lg">
+                Last Played Tournaments
+              </dt>
+              <dd>
+                <div class="flex flex-col gap-y-3">
+                  <Show
+                    when={teamQuery.data?.tournaments && teamQuery.data.tournaments.length > 0}
+                    fallback={<p class="text-gray-500">No tournaments</p>}
+                  >
+                    {teamQuery.data?.tournaments.map(tournament => (
+                      <A
+                        href={`/tournament/${tournament.event.slug}/team/${params.slug}`}
+                        class="flex items-center gap-3 rounded-md bg-gray-100 p-3 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
+                      >
+                        <Show when={tournament.logo_light || tournament.logo_dark}>
+                          <img
+                            src={tournament.logo_dark || tournament.logo_light}
+                            alt="Tournament logo"
+                            class="hidden h-12 w-12 rounded-sm object-contain dark:block"
+                          />
+                          <img
+                            src={tournament.logo_light || tournament.logo_dark}
+                            alt="Tournament logo"
+                            class="block h-12 w-12 rounded-sm object-contain dark:hidden"
+                          />
+                        </Show>
+                        <div class="flex-1">
+                          <h3 class="text-sm font-bold text-gray-700 dark:text-white">
+                            {tournament.event.title}
+                          </h3>
+                          <Show when={tournament.current_seed}>
+                            <p class="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                              Seed: {tournament.current_seed}
+                            </p>
+                          </Show>
+                        </div>
+                      </A>
+                    ))}
+                  </Show>
+                </div>
+              </dd>
+            </div>
+          </dl>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/tournament/TournamentCard.js
+++ b/frontend/src/components/tournament/TournamentCard.js
@@ -1,5 +1,5 @@
 import { A } from "@solidjs/router";
-import { Show } from "solid-js";
+import { Match, Show, Switch } from "solid-js";
 
 const TournamentCard = props => {
   return (
@@ -15,12 +15,8 @@ const TournamentCard = props => {
         <Show when={props.tournament.event?.type}>
           <span class="mr-2 h-fit rounded bg-blue-200 px-2.5 py-0.5 text-sm font-medium text-blue-800 dark:bg-green-900 dark:text-green-300">
             <Switch>
-              <Match when={props.tournament.event?.type === "MXD"}>
-                Mixed
-              </Match>
-              <Match when={props.tournament.event?.type === "OPN"}>
-                Opens
-              </Match>
+              <Match when={props.tournament.event?.type === "MXD"}>Mixed</Match>
+              <Match when={props.tournament.event?.type === "OPN"}>Opens</Match>
               <Match when={props.tournament.event?.type === "WMN"}>
                 Womens
               </Match>
@@ -89,7 +85,8 @@ const TournamentCard = props => {
           })}
           <Show
             when={
-              props.tournament.event.start_date !== props.tournament.event.end_date
+              props.tournament.event.start_date !==
+              props.tournament.event.end_date
             }
           >
             {" "}
@@ -107,7 +104,7 @@ const TournamentCard = props => {
         {props.children}
       </A>
     </Show>
-  )
+  );
 };
 
 export default TournamentCard;

--- a/frontend/src/components/tournament/TournamentCard.js
+++ b/frontend/src/components/tournament/TournamentCard.js
@@ -1,0 +1,113 @@
+import { A } from "@solidjs/router";
+import { Show } from "solid-js";
+
+const TournamentCard = props => {
+  return (
+    <Show when={props.tournament.status !== "DFT"}>
+      <A
+        href={
+          props.tournament.status === "REG" || props.tournament.status === "SCH"
+            ? `/tournament/${props.tournament.event?.slug}/register`
+            : `/tournament/${props.tournament.event?.slug}`
+        }
+        class="block w-full rounded-lg border border-blue-600 bg-white p-4 shadow dark:border-blue-400 dark:bg-gray-800"
+      >
+        <Show when={props.tournament.event?.type}>
+          <span class="mr-2 h-fit rounded bg-blue-200 px-2.5 py-0.5 text-sm font-medium text-blue-800 dark:bg-green-900 dark:text-green-300">
+            <Switch>
+              <Match when={props.tournament.event?.type === "MXD"}>
+                Mixed
+              </Match>
+              <Match when={props.tournament.event?.type === "OPN"}>
+                Opens
+              </Match>
+              <Match when={props.tournament.event?.type === "WMN"}>
+                Womens
+              </Match>
+            </Switch>
+          </span>
+        </Show>
+
+        <Switch>
+          <Match when={props.tournament.status === "REG"}>
+            <span class="h-fit rounded bg-green-200 px-2.5 py-0.5 text-sm font-medium text-green-800 dark:bg-green-900 dark:text-green-300">
+              Registrations open
+            </span>
+          </Match>
+          <Match when={props.tournament.status === "SCH"}>
+            <span class="h-fit rounded bg-yellow-100 px-2.5 py-0.5 text-sm font-medium text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300">
+              Registrations closed
+            </span>
+          </Match>
+          <Match when={props.tournament.status === "LIV"}>
+            <span
+              class={clsx(
+                "h-fit rounded px-2.5 py-0.5 text-sm font-medium",
+                new Date(Date.now()) < Date.parse(props.tournament.start_date)
+                  ? "bg-blue-200 text-blue-800 dark:bg-blue-900 dark:text-blue-300"
+                  : "bg-red-200 text-red-800 dark:bg-red-900 dark:text-red-300"
+              )}
+            >
+              {new Date(Date.now()) < Date.parse(props.tournament.start_date)
+                ? "Upcoming"
+                : "Live"}
+            </span>
+          </Match>
+          <Match when={props.tournament.status === "COM"}>
+            <span class="h-fit rounded bg-gray-300 px-2.5 py-0.5 text-sm font-medium text-gray-700 dark:bg-gray-900 dark:text-gray-300">
+              Completed
+            </span>
+          </Match>
+        </Switch>
+        <div class="mb-2 mt-2">
+          <h5 class="text-xl font-bold capitalize tracking-tight text-blue-600 dark:text-blue-400">
+            {props.tournament.event.title}
+          </h5>
+          <Show when={props.tournament.event?.series}>
+            <p class="text-sm italic">
+              Part of{" "}
+              <span class="text-blue-600">
+                {props.tournament.event?.series?.name}
+              </span>
+            </p>
+          </Show>
+        </div>
+
+        <div class="flex justify-between">
+          <span class="flex-grow text-sm capitalize">
+            {props.tournament.event.location}
+          </span>
+        </div>
+        <p class="text-sm text-blue-600 dark:text-blue-400">
+          {new Date(
+            Date.parse(props.tournament.event.start_date)
+          ).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+            timeZone: "UTC"
+          })}
+          <Show
+            when={
+              props.tournament.event.start_date !== props.tournament.event.end_date
+            }
+          >
+            {" "}
+            to{" "}
+            {new Date(
+              Date.parse(props.tournament.event.end_date)
+            ).toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "short",
+              day: "numeric",
+              timeZone: "UTC"
+            })}
+          </Show>
+        </p>
+        {props.children}
+      </A>
+    </Show>
+  )
+};
+
+export default TournamentCard;

--- a/server/api.py
+++ b/server/api.py
@@ -79,6 +79,7 @@ from server.schema import (
     RegistrationWardSchema,
     Response,
     TeamCreateSchema,
+    TeamDetailedSchema,
     TeamNameUpdateSchema,
     TeamSchema,
     TeamUpdateSchema,
@@ -352,7 +353,7 @@ def search_teams(request: AuthenticatedHttpRequest, text: str = "") -> QuerySet[
     return Team.objects.filter(name__icontains=text.lower()).order_by("name")
 
 
-@api.get("/team/{team_slug}", auth=None, response={200: TeamSchema, 400: Response})
+@api.get("/team/{team_slug}", auth=None, response={200: TeamDetailedSchema, 400: Response})
 def get_team(
     request: AuthenticatedHttpRequest, team_slug: str
 ) -> tuple[int, Team | message_response]:

--- a/server/schema.py
+++ b/server/schema.py
@@ -14,6 +14,7 @@ from server.core.models import (
 from server.membership.models import (
     Membership,
 )
+from server.tournament.models import Tournament, Event
 from server.utils import mask_string
 
 
@@ -118,8 +119,62 @@ class UserMinSchema(ModelSchema):
         ]
 
 
+class EventTinySchema(ModelSchema):
+    class Config:
+        model = Event
+        model_fields = ["title", "slug"]
+
+class TournamentTinySchema(ModelSchema):
+    event: EventTinySchema
+    current_seed: int | None
+
+    @staticmethod
+    def resolve_current_seed(tournament: Tournament) -> int | None:
+        # Default resolver returns None since we don't have team context here
+        # The actual value will be set in TeamSchema.resolve_tournaments
+        return None
+
+    class Config:
+        model = Tournament
+        model_fields = ["event", "logo_light", "logo_dark"]
+
+
+def get_team_seeding_position(tournament: Tournament, team_id: int) -> int | None:
+    """Find the seeding position for a specific team in the tournament's current_seeding."""
+    if not tournament.current_seeding:
+        return None
+    for seed_pos, tid in tournament.current_seeding.items():
+        if tid == team_id:
+            # Convert seed_pos to int if it's a string
+            try:
+                return int(seed_pos)
+            except (ValueError, TypeError):
+                return None
+    return None
+
 class TeamSchema(ModelSchema):
     admins: list[UserMinSchema]
+    tournaments: list[TournamentTinySchema]
+
+    @staticmethod
+    def resolve_tournaments(team: Team) -> list[TournamentTinySchema]:
+        # Filter tournaments to only include LIVE or COMPLETED status
+        filtered_tournaments = team.tournaments.filter(
+            status__in=[Tournament.Status.LIVE, Tournament.Status.COMPLETED]
+        )
+
+        result = []
+        for tournament in filtered_tournaments:
+            # Create schema instance
+            schema_instance = TournamentTinySchema.from_orm(tournament)
+            # Get the seeding position for this team
+            seeding_position = get_team_seeding_position(tournament, team.id)
+            # Create a new instance with the seeding position
+            schema_dict = schema_instance.dict()
+            schema_dict["current_seed"] = seeding_position
+            result.append(TournamentTinySchema(**schema_dict))
+
+        return result
 
     class Config:
         model = Team


### PR DESCRIPTION
This PR achieves the following:
- Update TeamSchema to include details of tournaments that the team has played in
- Update teams/View.js so that only one admin email is shown per line
- Update teams/View.js to include details of the last played tournaments

Open questions:
- How many tournaments do we want to display? (Currently limited to latest 5)
- Do we want to create something like `TeamDetailedSchema` that is only used in the team page? Now that this is currently in `TeamSchema`, every schema that uses `TeamSchema` will end up needing to do these additional queries for tournament data which is unnecessary
- How do we style the tournament data? Is there a standard approach or a styling guideline that we follow?
- Is there any other tournament data we want to display on the team page (spirit ranking, tournament status, etc.)?
