### PR TITLE
frontend: Preserve newlines in form description

### DIFF
--- a/frontend/src/components/forms/FormView.js
+++ b/frontend/src/components/forms/FormView.js
@@ -138,7 +138,7 @@ const FormView = () => {
             {formQuery.data.title}
           </h1>
           <Show when={formQuery.data.description}>
-            <p class="mt-2 text-gray-600 dark:text-gray-300">
+            <p class="mt-2 whitespace-pre-line text-gray-600 dark:text-gray-300">
               {formQuery.data.description}
             </p>
           </Show>


### PR DESCRIPTION
The form description is rendered in plain HTML, which collapses line breaks into spaces, so multi-line and blank-line formatting was lost. Render it with whitespace-pre-line so newlines (including empty lines) are preserved.