### PR TITLE
forms: Allow closing submissions and CSV export

### DIFF
--- a/frontend/src/components/forms/FormBuilder.js
+++ b/frontend/src/components/forms/FormBuilder.js
@@ -27,6 +27,7 @@ const FormBuilder = () => {
   const [title, setTitle] = createSignal("");
   const [description, setDescription] = createSignal("");
   const [paymentAmount, setPaymentAmount] = createSignal("");
+  const [isActive, setIsActive] = createSignal(true);
   const [fields, setFields] = createStore([]);
   const [status, setStatus] = createSignal("");
   const [saving, setSaving] = createSignal(false);
@@ -77,6 +78,7 @@ const FormBuilder = () => {
         setPaymentAmount(
           form.payment_amount ? String(form.payment_amount / 100) : ""
         );
+        setIsActive(form.is_active !== false);
         setFields(
           form.fields.map(f => ({
             key: f.key,
@@ -105,6 +107,7 @@ const FormBuilder = () => {
       payment_amount: paymentAmount()
         ? Math.round(Number(paymentAmount()) * 100)
         : null,
+      is_active: isActive(),
       fields: fields.map(f => ({
         key: f.key,
         label: f.label,
@@ -223,6 +226,15 @@ const FormBuilder = () => {
             class="w-full rounded-lg border border-gray-300 p-2.5 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
           />
         </div>
+
+        <label class="flex items-center gap-2 text-sm text-gray-900 dark:text-white">
+          <input
+            type="checkbox"
+            checked={isActive()}
+            onChange={e => setIsActive(e.target.checked)}
+          />
+          Accepting responses
+        </label>
 
         <div class="space-y-4">
           <h2 class="text-lg font-semibold text-gray-900 dark:text-white">

--- a/frontend/src/components/forms/FormResponses.js
+++ b/frontend/src/components/forms/FormResponses.js
@@ -1,13 +1,21 @@
 import { useParams } from "@solidjs/router";
-import { createQuery } from "@tanstack/solid-query";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { documentText } from "solid-heroicons/solid";
-import { For, Show, Suspense } from "solid-js";
+import { createSignal, For, Show, Suspense } from "solid-js";
 
-import { fetchForm, fetchFormResponses } from "../../queries";
+import {
+  downloadFormResponsesCsv,
+  fetchForm,
+  fetchFormResponses,
+  updateForm
+} from "../../queries";
 import Breadcrumbs from "../Breadcrumbs";
 
 const FormResponses = () => {
   const params = useParams();
+  const queryClient = useQueryClient();
+  const [actionStatus, setActionStatus] = createSignal("");
+  const [busy, setBusy] = createSignal(false);
 
   const formQuery = createQuery(
     () => ["form", params.slug],
@@ -28,6 +36,45 @@ const FormResponses = () => {
       ? "-"
       : value;
 
+  const toggleAcceptingSubmissions = async () => {
+    const form = formQuery.data;
+    if (!form || busy()) return;
+
+    setBusy(true);
+    setActionStatus("");
+    try {
+      await updateForm({
+        slug: params.slug,
+        data: {
+          title: form.title,
+          description: form.description,
+          fields: form.fields,
+          payment_amount: form.payment_amount,
+          is_active: !form.is_active
+        }
+      });
+      await queryClient.invalidateQueries(["form", params.slug]);
+      await queryClient.invalidateQueries(["forms"]);
+    } catch (err) {
+      setActionStatus(`Error: ${err.message}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDownloadCsv = async () => {
+    if (busy()) return;
+    setBusy(true);
+    setActionStatus("");
+    try {
+      await downloadFormResponsesCsv(params.slug);
+    } catch (err) {
+      setActionStatus(`Error: ${err.message}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
     <div>
       <Breadcrumbs
@@ -38,9 +85,45 @@ const FormResponses = () => {
           { name: "Responses" }
         ]}
       />
-      <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
-        Responses — {formQuery.data?.title}
-      </h1>
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+          Responses — {formQuery.data?.title}
+        </h1>
+        <div class="flex flex-wrap gap-2">
+          <Show when={formQuery.data}>
+            <button
+              type="button"
+              disabled={busy()}
+              onClick={toggleAcceptingSubmissions}
+              class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              {formQuery.data.is_active
+                ? "Stop accepting responses"
+                : "Resume accepting responses"}
+            </button>
+          </Show>
+          <Show when={responsesQuery.data?.length}>
+            <button
+              type="button"
+              disabled={busy()}
+              onClick={handleDownloadCsv}
+              class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400"
+            >
+              Download CSV
+            </button>
+          </Show>
+        </div>
+      </div>
+
+      <Show when={formQuery.data && !formQuery.data.is_active}>
+        <p class="mt-3 rounded-lg bg-amber-50 p-3 text-sm text-amber-800 dark:bg-gray-800 dark:text-amber-200">
+          This form is not accepting new responses.
+        </p>
+      </Show>
+
+      <Show when={actionStatus()}>
+        <p class="mt-3 text-sm text-red-500">{actionStatus()}</p>
+      </Show>
 
       <Suspense fallback={<p class="mt-6 text-gray-500">Loading...</p>}>
         <Show

--- a/frontend/src/components/forms/FormView.js
+++ b/frontend/src/components/forms/FormView.js
@@ -176,128 +176,139 @@ const FormView = () => {
           </Show>
 
           <Show
-            when={!done()}
+            when={formQuery.data.is_active}
             fallback={
-              <p class="mt-6 text-green-600 dark:text-green-400">{status()}</p>
+              <p class="mt-6 rounded-lg bg-gray-100 p-4 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                This form is no longer accepting responses.
+              </p>
             }
           >
-            <form class="mt-6 space-y-5" onSubmit={handleSubmit}>
-              <For each={formQuery.data.fields}>
-                {field => (
-                  <div>
-                    <label
-                      class="mb-1 block text-sm font-medium text-gray-900 dark:text-white"
-                      for={field.key}
-                    >
-                      {field.label}
-                      <Show when={field.required}>
-                        <span class="ml-1 text-red-500">*</span>
-                      </Show>
-                    </label>
-                    <Switch>
-                      <Match when={field.type === "textarea"}>
-                        <textarea
-                          id={field.key}
-                          required={field.required}
-                          class="w-full rounded-lg border border-gray-300 p-2.5 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-                          rows="4"
-                          onInput={e => setValue(field.key, e.target.value)}
-                        />
-                      </Match>
-                      <Match when={field.type === "dropdown"}>
-                        <select
-                          id={field.key}
-                          required={field.required}
-                          class="w-full rounded-lg border border-gray-300 p-2.5 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-                          onChange={e => setValue(field.key, e.target.value)}
-                        >
-                          <option value="">Select...</option>
-                          <For each={field.options}>
-                            {opt => <option value={opt}>{opt}</option>}
-                          </For>
-                        </select>
-                      </Match>
-                      <Match when={field.type === "radio"}>
-                        <div class="space-y-1">
-                          <For each={field.options}>
-                            {opt => (
-                              <label class="flex items-center gap-2 text-sm text-gray-900 dark:text-white">
-                                <input
-                                  type="radio"
-                                  name={field.key}
-                                  value={opt}
-                                  required={field.required}
-                                  onChange={() => setValue(field.key, opt)}
-                                />
-                                {opt}
-                              </label>
-                            )}
-                          </For>
-                        </div>
-                      </Match>
-                      <Match when={field.type === "checkbox"}>
-                        <div class="space-y-1">
-                          <For each={field.options}>
-                            {opt => (
-                              <label class="flex items-center gap-2 text-sm text-gray-900 dark:text-white">
-                                <input
-                                  type="checkbox"
-                                  value={opt}
-                                  onChange={e =>
-                                    toggleCheckbox(
-                                      field.key,
-                                      opt,
-                                      e.target.checked
-                                    )
-                                  }
-                                />
-                                {opt}
-                              </label>
-                            )}
-                          </For>
-                        </div>
-                      </Match>
-                      <Match when={true}>
-                        <input
-                          id={field.key}
-                          type={
-                            field.type === "number"
-                              ? "number"
-                              : field.type === "email"
-                              ? "email"
-                              : field.type === "date"
-                              ? "date"
-                              : "text"
-                          }
-                          required={field.required}
-                          class="w-full rounded-lg border border-gray-300 p-2.5 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-                          onInput={e => setValue(field.key, e.target.value)}
-                        />
-                      </Match>
-                    </Switch>
-                  </div>
-                )}
-              </For>
+            <Show
+              when={!done()}
+              fallback={
+                <p class="mt-6 text-green-600 dark:text-green-400">
+                  {status()}
+                </p>
+              }
+            >
+              <form class="mt-6 space-y-5" onSubmit={handleSubmit}>
+                <For each={formQuery.data.fields}>
+                  {field => (
+                    <div>
+                      <label
+                        class="mb-1 block text-sm font-medium text-gray-900 dark:text-white"
+                        for={field.key}
+                      >
+                        {field.label}
+                        <Show when={field.required}>
+                          <span class="ml-1 text-red-500">*</span>
+                        </Show>
+                      </label>
+                      <Switch>
+                        <Match when={field.type === "textarea"}>
+                          <textarea
+                            id={field.key}
+                            required={field.required}
+                            class="w-full rounded-lg border border-gray-300 p-2.5 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                            rows="4"
+                            onInput={e => setValue(field.key, e.target.value)}
+                          />
+                        </Match>
+                        <Match when={field.type === "dropdown"}>
+                          <select
+                            id={field.key}
+                            required={field.required}
+                            class="w-full rounded-lg border border-gray-300 p-2.5 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                            onChange={e => setValue(field.key, e.target.value)}
+                          >
+                            <option value="">Select...</option>
+                            <For each={field.options}>
+                              {opt => <option value={opt}>{opt}</option>}
+                            </For>
+                          </select>
+                        </Match>
+                        <Match when={field.type === "radio"}>
+                          <div class="space-y-1">
+                            <For each={field.options}>
+                              {opt => (
+                                <label class="flex items-center gap-2 text-sm text-gray-900 dark:text-white">
+                                  <input
+                                    type="radio"
+                                    name={field.key}
+                                    value={opt}
+                                    required={field.required}
+                                    onChange={() => setValue(field.key, opt)}
+                                  />
+                                  {opt}
+                                </label>
+                              )}
+                            </For>
+                          </div>
+                        </Match>
+                        <Match when={field.type === "checkbox"}>
+                          <div class="space-y-1">
+                            <For each={field.options}>
+                              {opt => (
+                                <label class="flex items-center gap-2 text-sm text-gray-900 dark:text-white">
+                                  <input
+                                    type="checkbox"
+                                    value={opt}
+                                    onChange={e =>
+                                      toggleCheckbox(
+                                        field.key,
+                                        opt,
+                                        e.target.checked
+                                      )
+                                    }
+                                  />
+                                  {opt}
+                                </label>
+                              )}
+                            </For>
+                          </div>
+                        </Match>
+                        <Match when={true}>
+                          <input
+                            id={field.key}
+                            type={
+                              field.type === "number"
+                                ? "number"
+                                : field.type === "email"
+                                ? "email"
+                                : field.type === "date"
+                                ? "date"
+                                : "text"
+                            }
+                            required={field.required}
+                            class="w-full rounded-lg border border-gray-300 p-2.5 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                            onInput={e => setValue(field.key, e.target.value)}
+                          />
+                        </Match>
+                      </Switch>
+                    </div>
+                  )}
+                </For>
 
-              <Show when={status() && !done()}>
-                <p class="text-sm text-red-500">{status()}</p>
-              </Show>
-
-              <button
-                type="submit"
-                disabled={submitting()}
-                class="rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400"
-              >
-                <Show
-                  when={formQuery.data.payment_amount}
-                  fallback={submitting() ? "Submitting..." : "Submit"}
-                >
-                  {submitting()
-                    ? "Processing..."
-                    : `Pay ₹${formQuery.data.payment_amount / 100} & Submit`}
+                <Show when={status() && !done()}>
+                  <p class="text-sm text-red-500">{status()}</p>
                 </Show>
-              </button>
-            </form>
+
+                <button
+                  type="submit"
+                  disabled={submitting()}
+                  class="rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400"
+                >
+                  <Show
+                    when={formQuery.data.payment_amount}
+                    fallback={submitting() ? "Submitting..." : "Submit"}
+                  >
+                    {submitting()
+                      ? "Processing..."
+                      : `Pay ₹${formQuery.data.payment_amount / 100} & Submit`}
+                  </Show>
+                </button>
+              </form>
+            </Show>
           </Show>
         </Show>
       </Suspense>

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -2227,6 +2227,24 @@ export const fetchFormResponses = async slug => {
   return await response.json();
 };
 
+export const downloadFormResponsesCsv = async slug => {
+  const response = await fetch(`/api/forms/${slug}/responses/csv`, {
+    method: "GET",
+    credentials: "same-origin"
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data?.message || "Failed to download responses");
+  }
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${slug}-responses.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
 export const fetchMyFormResponses = async slug => {
   const response = await fetch(`/api/forms/${slug}/my-responses`, {
     method: "GET",

--- a/server/forms/api.py
+++ b/server/forms/api.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from django.db.models import QuerySet
+from django.http import HttpResponse
 from ninja import Router
 
 from server.schema import Response
@@ -18,7 +19,12 @@ from .schema import (
     FormSubmitResponseSchema,
     MyFormResponseSchema,
 )
-from .utils import create_form_payment_order, send_form_submission_email, validate_answers
+from .utils import (
+    build_responses_csv,
+    create_form_payment_order,
+    send_form_submission_email,
+    validate_answers,
+)
 
 router = Router()
 
@@ -52,6 +58,7 @@ def create_form(
         slug=_unique_slug(data.title),
         fields=[f.dict() for f in data.fields],
         payment_amount=data.payment_amount,
+        is_active=data.is_active,
         created_by=request.user,
     )
     return 200, form
@@ -81,7 +88,8 @@ def update_form(
     form.description = data.description
     form.fields = [f.dict() for f in data.fields]
     form.payment_amount = data.payment_amount
-    form.save(update_fields=["title", "description", "fields", "payment_amount"])
+    form.is_active = data.is_active
+    form.save(update_fields=["title", "description", "fields", "payment_amount", "is_active"])
     return 200, form
 
 
@@ -135,6 +143,28 @@ def list_responses(
         200,
         form.responses.filter(is_paid=True).select_related("user").order_by("-submitted_at"),
     )
+
+
+@router.get(
+    "/{slug}/responses/csv",
+    response={200: None, 401: Response, 404: Response},
+)
+def export_responses_csv(
+    request: AuthenticatedHttpRequest, slug: str
+) -> HttpResponse | tuple[int, message_response]:
+    if not request.user.is_staff:
+        return 401, {"message": "Only Admins can download responses"}
+
+    try:
+        form = Form.objects.get(slug=slug)
+    except Form.DoesNotExist:
+        return 404, {"message": "Form does not exist"}
+
+    responses = form.responses.filter(is_paid=True).select_related("user").order_by("-submitted_at")
+    csv_content = build_responses_csv(form, responses)
+    response = HttpResponse(csv_content, content_type="text/csv")
+    response["Content-Disposition"] = f'attachment; filename="{form.slug}-responses.csv"'
+    return response
 
 
 @router.get("/{slug}/my-responses", response={200: list[MyFormResponseSchema], 404: Response})

--- a/server/forms/schema.py
+++ b/server/forms/schema.py
@@ -18,6 +18,7 @@ class FormCreateSchema(Schema):
     description: str = ""
     fields: list[FormFieldSchema]
     payment_amount: int | None = None
+    is_active: bool = True
 
 
 class FormListSchema(ModelSchema):

--- a/server/forms/utils.py
+++ b/server/forms/utils.py
@@ -1,13 +1,48 @@
+import csv
+import io
 import time
 from typing import Any
 
 from django.conf import settings
 from django.core import mail
+from django.db.models import QuerySet
 
 from server.transaction.client import razorpay
 from server.transaction.models import AuthenticatedHttpRequest, RazorpayTransaction
 
 from .models import CHOICE_FIELD_TYPES, FieldType, Form, FormResponse
+
+
+def format_answer_for_csv(value: Any) -> str:
+    if value is None or value == "":
+        return ""
+    if isinstance(value, list):
+        return ", ".join(str(v) for v in value)
+    return str(value)
+
+
+def build_responses_csv(form: Form, responses: QuerySet[FormResponse] | list[FormResponse]) -> str:
+    """Build a CSV string of form responses for staff download."""
+    field_defs = form.fields or []
+    headers = ["Name", "Email", "Phone", "Submitted"] + [
+        str(f.get("label") or f.get("key") or "") for f in field_defs
+    ]
+    field_keys = [str(f.get("key") or "") for f in field_defs]
+
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(headers)
+    for response in responses:
+        answers = response.answers or {}
+        row = [
+            response.user.get_full_name(),
+            response.user.email,
+            response.user.phone,
+            response.submitted_at.isoformat(sep=" ", timespec="seconds"),
+        ]
+        row.extend(format_answer_for_csv(answers.get(key)) for key in field_keys)
+        writer.writerow(row)
+    return buffer.getvalue()
 
 
 def validate_answers(form: Form, answers: dict[str, Any]) -> str | None:

--- a/server/tests/test_forms.py
+++ b/server/tests/test_forms.py
@@ -1,0 +1,163 @@
+import csv
+import io
+import json
+
+from django.test import Client, TestCase
+
+from server.core.models import User
+from server.forms.models import Form, FormResponse
+
+TEST_PASSWORD = "test_password_123"  # nosec B105
+
+
+class FormsAPITestCase(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        self.staff = User.objects.create_user(
+            username="staff",
+            email="staff@example.com",
+            password=TEST_PASSWORD,
+            phone="9999999999",
+            first_name="Staff",
+            last_name="User",
+            is_staff=True,
+        )
+        self.user = User.objects.create_user(
+            username="member",
+            email="member@example.com",
+            password=TEST_PASSWORD,
+            phone="8888888888",
+            first_name="Member",
+            last_name="User",
+        )
+        self.form = Form.objects.create(
+            title="Feedback Form",
+            slug="feedback-form",
+            description="Tell us what you think",
+            fields=[
+                {
+                    "key": "comments",
+                    "label": "Comments",
+                    "type": "textarea",
+                    "required": True,
+                    "options": [],
+                },
+                {
+                    "key": "rating",
+                    "label": "Rating",
+                    "type": "dropdown",
+                    "required": False,
+                    "options": ["Good", "Okay", "Bad"],
+                },
+            ],
+            payment_amount=None,
+            is_active=True,
+            created_by=self.staff,
+        )
+
+    def _login(self, user: User) -> None:
+        self.client.force_login(user)
+
+    def test_update_form_can_stop_accepting_responses(self) -> None:
+        self._login(self.staff)
+        payload = {
+            "title": self.form.title,
+            "description": self.form.description,
+            "fields": self.form.fields,
+            "payment_amount": None,
+            "is_active": False,
+        }
+        response = self.client.put(
+            f"/api/forms/{self.form.slug}",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertFalse(data["is_active"])
+        self.form.refresh_from_db()
+        self.assertFalse(self.form.is_active)
+
+    def test_submit_rejected_when_form_inactive(self) -> None:
+        self.form.is_active = False
+        self.form.save(update_fields=["is_active"])
+        self._login(self.user)
+
+        response = self.client.post(
+            f"/api/forms/{self.form.slug}/responses",
+            data=json.dumps({"answers": {"comments": "Hello"}}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("not active", response.json()["message"])
+        self.assertEqual(FormResponse.objects.count(), 0)
+
+    def test_submit_allowed_when_form_active(self) -> None:
+        self._login(self.user)
+        response = self.client.post(
+            f"/api/forms/{self.form.slug}/responses",
+            data=json.dumps({"answers": {"comments": "Great event", "rating": "Good"}}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+        self.assertEqual(FormResponse.objects.filter(is_paid=True).count(), 1)
+
+    def test_inactive_forms_hidden_from_non_staff_list(self) -> None:
+        self.form.is_active = False
+        self.form.save(update_fields=["is_active"])
+
+        self._login(self.user)
+        response = self.client.get("/api/forms/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+        self._login(self.staff)
+        response = self.client.get("/api/forms/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        self.assertFalse(response.json()[0]["is_active"])
+
+    def test_export_responses_csv(self) -> None:
+        FormResponse.objects.create(
+            form=self.form,
+            user=self.user,
+            answers={"comments": "Loved it", "rating": "Good"},
+            is_paid=True,
+        )
+        FormResponse.objects.create(
+            form=self.form,
+            user=self.user,
+            answers={"comments": "Needs work", "rating": ["Okay", "Bad"]},
+            is_paid=True,
+        )
+        # Unpaid responses must not appear in the export.
+        FormResponse.objects.create(
+            form=self.form,
+            user=self.user,
+            answers={"comments": "draft"},
+            is_paid=False,
+        )
+
+        self._login(self.staff)
+        response = self.client.get(f"/api/forms/{self.form.slug}/responses/csv")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertIn("feedback-form-responses.csv", response["Content-Disposition"])
+
+        rows = list(csv.reader(io.StringIO(response.content.decode())))
+        self.assertEqual(rows[0], ["Name", "Email", "Phone", "Submitted", "Comments", "Rating"])
+        self.assertEqual(len(rows), 3)  # header + 2 paid responses
+        # Newest first
+        self.assertEqual(rows[1][0], "Member User")
+        self.assertEqual(rows[1][1], "member@example.com")
+        self.assertEqual(rows[1][2], "8888888888")
+        self.assertEqual(rows[1][4], "Needs work")
+        self.assertEqual(rows[1][5], "Okay, Bad")
+        self.assertEqual(rows[2][4], "Loved it")
+        self.assertEqual(rows[2][5], "Good")
+
+    def test_export_responses_csv_requires_staff(self) -> None:
+        self._login(self.user)
+        response = self.client.get(f"/api/forms/{self.form.slug}/responses/csv")
+        self.assertEqual(response.status_code, 401)


### PR DESCRIPTION
Staff can stop accepting responses and download paid responses as CSV from the responses page.