### PR TITLE
gitignore: Match .DS_Store in nested directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,4 @@ cython_debug/
 /secrets
 /cron/
 /.vscode
-/.DS_STORE
+.DS_Store


### PR DESCRIPTION
Split out of #551.

The pattern only matched `.DS_Store` at the repo root, so nested ones kept
showing up as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)