### PR TITLE
tournament: Fix pre-start re-seeding and apply WFDF tie-breaks

### DIFF
--- a/server/api.py
+++ b/server/api.py
@@ -171,10 +171,10 @@ from server.tournament.utils import (
     populate_fixtures,
     rerun_swiss_round,
     update_match_score_and_results,
+    update_tournament_seeding,
     update_tournament_spirit_rankings,
     user_tournament_teams,
     validate_new_pool,
-    validate_seeds_and_teams,
 )
 from server.transaction.api import router as transaction_router
 from server.types import message_response
@@ -1913,16 +1913,9 @@ def update_standings(
     except Tournament.DoesNotExist:
         return 400, {"message": "Tournament does not exist"}
 
-    valid_seeds_and_teams, errors = validate_seeds_and_teams(tournament, tournament_details.seeding)
-
-    if not valid_seeds_and_teams:
-        message = "Cannot update standings, due to following errors: \n"
-        message += "\n".join(f"{key}: {value}" for key, value in errors.items())
-        return 400, {"message": message}
-
-    tournament.initial_seeding = dict(sorted(tournament_details.seeding.items()))
-    tournament.current_seeding = dict(sorted(tournament_details.seeding.items()))
-    tournament.save()
+    ok, error = update_tournament_seeding(tournament, tournament_details.seeding)
+    if not ok:
+        return 400, error or {"message": "Cannot update seeding"}
 
     return 200, tournament
 

--- a/server/api.py
+++ b/server/api.py
@@ -174,6 +174,7 @@ from server.tournament.utils import (
     update_tournament_seeding,
     update_tournament_spirit_rankings,
     user_tournament_teams,
+    validate_bracket_name,
     validate_new_pool,
 )
 from server.transaction.api import router as transaction_router
@@ -2167,6 +2168,10 @@ def create_bracket(
         tournament = Tournament.objects.get(id=tournament_id)
     except Tournament.DoesNotExist:
         return 400, {"message": "Tournament does not exist"}
+
+    valid_name, name_error = validate_bracket_name(tournament, bracket_details.name)
+    if not valid_name:
+        return 400, name_error or {"message": "Invalid bracket name"}
 
     bracket_seeding = {}
     start, end = map(int, bracket_details.name.split("-"))

--- a/server/tests/test_seeding_and_tiebreakers.py
+++ b/server/tests/test_seeding_and_tiebreakers.py
@@ -1,0 +1,178 @@
+"""Tests for pre-start seeding re-sync."""
+
+from server.tests.base import ApiBaseTestCase
+from server.tournament.models import Match, Pool, SwissRound
+
+
+class SeedingUpdateResyncTests(ApiBaseTestCase):
+    """Re-seeding before the tournament starts must re-sync pool snapshots."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.client.force_login(self.user)
+
+        for name, seeds in (("A", [1, 4, 5, 8]), ("B", [2, 3, 6, 7])):
+            response = self.client.post(
+                f"/api/tournament/pool/{self.tournament.id}",
+                {
+                    "name": name,
+                    "sequence_number": 1 if name == "A" else 2,
+                    "seeding": seeds,
+                },
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 200)
+        self.pool_a = Pool.objects.get(tournament=self.tournament, name="A")
+        self.pool_b = Pool.objects.get(tournament=self.tournament, name="B")
+
+    def _swapped_seeding(self) -> dict[str, int]:
+        """Original seeding with seeds 1 and 2 swapped."""
+        seeding = {str(k): v for k, v in self.tournament.initial_seeding.items()}
+        seeding["1"], seeding["2"] = seeding["2"], seeding["1"]
+        return seeding
+
+    def test_reseed_resyncs_pool_teams(self) -> None:
+        original_seed_1_team = self.tournament.initial_seeding["1"]
+        original_seed_2_team = self.tournament.initial_seeding["2"]
+
+        response = self.client.put(
+            f"/api/tournament/update/{self.tournament.id}",
+            {"seeding": self._swapped_seeding()},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.pool_a.refresh_from_db()
+        self.pool_b.refresh_from_db()
+        # Seed 1 lives in pool A, seed 2 in pool B; both must now point at the
+        # swapped teams, with results re-keyed to the new team ids.
+        self.assertEqual(self.pool_a.initial_seeding["1"], original_seed_2_team)
+        self.assertEqual(self.pool_b.initial_seeding["2"], original_seed_1_team)
+        self.assertIn(str(original_seed_2_team), self.pool_a.results)
+        self.assertNotIn(str(original_seed_1_team), self.pool_a.results)
+        self.assertEqual(sorted(row["rank"] for row in self.pool_a.results.values()), [1, 2, 3, 4])
+
+    def test_reseed_keeps_matches_as_placeholders(self) -> None:
+        response = self.client.put(
+            f"/api/tournament/update/{self.tournament.id}",
+            {"seeding": self._swapped_seeding()},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        for match in Match.objects.filter(tournament=self.tournament):
+            self.assertIsNone(match.team_1)
+            self.assertIsNone(match.team_2)
+            self.assertEqual(match.status, Match.Status.YET_TO_FIX)
+
+    def test_start_after_reseed_assigns_new_teams(self) -> None:
+        original_seed_2_team = self.tournament.initial_seeding["2"]
+        response = self.client.put(
+            f"/api/tournament/update/{self.tournament.id}",
+            {"seeding": self._swapped_seeding()},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.post(f"/api/tournament/start/{self.tournament.id}")
+        self.assertEqual(response.status_code, 200)
+
+        # The seed-1 vs seed-4 match in pool A must feature the new seed-1 team
+        match = Match.objects.get(
+            tournament=self.tournament,
+            pool=self.pool_a,
+            placeholder_seed_1=1,
+            placeholder_seed_2=4,
+        )
+        self.assertEqual(match.team_1_id, original_seed_2_team)
+
+    def test_reseed_blocked_after_start(self) -> None:
+        response = self.client.post(f"/api/tournament/start/{self.tournament.id}")
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.put(
+            f"/api/tournament/update/{self.tournament.id}",
+            {"seeding": self._swapped_seeding()},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("after the tournament has started", response.json()["message"])
+
+    def test_invalid_seeding_still_rejected(self) -> None:
+        seeding = self._swapped_seeding()
+        seeding.pop("8")
+        response = self.client.put(
+            f"/api/tournament/update/{self.tournament.id}",
+            {"seeding": seeding},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+class SeedingUpdateResyncSwissTests(ApiBaseTestCase):
+    """Re-seeding must also re-sync Swiss group snapshots."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            f"/api/tournament/swiss-round/{self.tournament.id}",
+            {
+                "num_rounds": 3,
+                "seeding": [1, 2, 3, 4, 5, 6, 7, 8],
+                "sequence_number": 1,
+                "name": "A",
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.swiss_round = SwissRound.objects.get(tournament=self.tournament)
+
+    def test_reseed_resyncs_swiss_group(self) -> None:
+        original_seed_1_team = self.tournament.initial_seeding["1"]
+        original_seed_2_team = self.tournament.initial_seeding["2"]
+        seeding = {str(k): v for k, v in self.tournament.initial_seeding.items()}
+        seeding["1"], seeding["2"] = seeding["2"], seeding["1"]
+
+        response = self.client.put(
+            f"/api/tournament/update/{self.tournament.id}",
+            {"seeding": seeding},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.swiss_round.refresh_from_db()
+        self.assertEqual(self.swiss_round.initial_seeding["1"], original_seed_2_team)
+        self.assertEqual(self.swiss_round.initial_seeding["2"], original_seed_1_team)
+        self.assertIn(str(original_seed_1_team), self.swiss_round.results)
+        self.assertEqual(self.swiss_round.results[str(original_seed_2_team)]["rank"], 1)
+        self.assertEqual(self.swiss_round.results[str(original_seed_2_team)]["opp_strength"], 0)
+
+    def test_start_after_reseed_assigns_new_teams_to_round_one(self) -> None:
+        original_seed_2_team = self.tournament.initial_seeding["2"]
+        seeding = {str(k): v for k, v in self.tournament.initial_seeding.items()}
+        seeding["1"], seeding["2"] = seeding["2"], seeding["1"]
+
+        response = self.client.put(
+            f"/api/tournament/update/{self.tournament.id}",
+            {"seeding": seeding},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.post(f"/api/tournament/start/{self.tournament.id}")
+        self.assertEqual(response.status_code, 200)
+
+        # Round 1 pairs 1 vs 8; team at seed 1 must be the swapped team
+        match = Match.objects.get(
+            tournament=self.tournament,
+            swiss_round=self.swiss_round,
+            placeholder_seed_1=1,
+            placeholder_seed_2=8,
+        )
+        self.assertEqual(match.team_1_id, original_seed_2_team)

--- a/server/tests/test_seeding_and_tiebreakers.py
+++ b/server/tests/test_seeding_and_tiebreakers.py
@@ -11,6 +11,7 @@ from server.tournament.utils import (
     recompute_swiss_ranks,
     sort_swiss_tied_teams,
     sort_tied_teams,
+    validate_bracket_name,
 )
 
 
@@ -435,3 +436,70 @@ class SwissTieBreakRestartTests(ApiBaseTestCase):
         results, seeding = recompute_swiss_ranks(self.swiss_round, results, [1, 2], seeding)
         self.assertEqual(results[self.team_a.id]["rank"], 1)
         self.assertEqual(seeding[1], self.team_a.id)
+
+
+class BracketNameValidationTests(ApiBaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.client.force_login(self.user)
+
+    def _create(self, name: str) -> int:
+        response = self.client.post(
+            f"/api/tournament/bracket/{self.tournament.id}",
+            {"name": name, "sequence_number": 1},
+            content_type="application/json",
+        )
+        return response.status_code
+
+    def test_valid_bracket_creates_matches(self) -> None:
+        self.assertEqual(self._create("1-8"), 200)
+        bracket = Bracket.objects.get(tournament=self.tournament)
+        self.assertEqual(Match.objects.filter(bracket=bracket).count(), 12)
+
+    def test_non_numeric_name_rejected(self) -> None:
+        self.assertEqual(self._create("Top8"), 400)
+        self.assertEqual(Bracket.objects.filter(tournament=self.tournament).count(), 0)
+
+    def test_reversed_range_rejected(self) -> None:
+        self.assertEqual(self._create("8-1"), 400)
+
+    def test_odd_sized_range_rejected(self) -> None:
+        # Odd ranges used to create a bracket silently containing no matches
+        self.assertEqual(self._create("1-5"), 400)
+        self.assertEqual(Bracket.objects.filter(tournament=self.tournament).count(), 0)
+
+    def test_zero_seed_rejected(self) -> None:
+        self.assertEqual(self._create("0-3"), 400)
+
+    def test_seeds_beyond_the_registered_teams_rejected(self) -> None:
+        # Eight teams are registered, so a 9-16 bracket is a set of matches that
+        # could never be filled.
+        self.assertEqual(self._create("9-16"), 400)
+        self.assertEqual(Bracket.objects.filter(tournament=self.tournament).count(), 0)
+
+    def test_name_too_long_for_the_column_rejected(self) -> None:
+        # Enough teams that the seed range itself is legitimate: what fails is
+        # that "101-128" does not fit Bracket.name, which used to surface as a
+        # 500 from the database rather than a 400 from here.
+        registered = self.tournament.teams.count()
+        self.tournament.teams.add(
+            *[
+                Team.objects.create(name=f"Filler {i}", ultimate_central_id=1000 + i)
+                for i in range(128 - registered)
+            ]
+        )
+        ok, error = validate_bracket_name(self.tournament, "101-128")
+        self.assertFalse(ok)
+        self.assertIn("longer than", (error or {}).get("message", ""))
+        self.assertTrue(validate_bracket_name(self.tournament, "1-128")[0])
+
+    def test_validate_bracket_name_unit(self) -> None:
+        self.assertTrue(validate_bracket_name(self.tournament, "1-8")[0])
+        self.assertTrue(validate_bracket_name(self.tournament, "5-6")[0])
+        self.assertFalse(validate_bracket_name(self.tournament, "5-5")[0])
+        self.assertFalse(validate_bracket_name(self.tournament, "1-8-9")[0])
+        self.assertFalse(validate_bracket_name(self.tournament, "finals")[0])
+        # Only eight teams are registered, so seed 16 does not exist.
+        self.assertFalse(validate_bracket_name(self.tournament, "9-16")[0])

--- a/server/tests/test_seeding_and_tiebreakers.py
+++ b/server/tests/test_seeding_and_tiebreakers.py
@@ -1,7 +1,17 @@
-"""Tests for pre-start seeding re-sync."""
+"""Tests for pre-start seeding re-sync and WFDF-style tie-breaker fixes."""
 
+from typing import Any
+
+from server.core.models import Team
 from server.tests.base import ApiBaseTestCase
-from server.tournament.models import Match, Pool, SwissRound
+from server.tournament.models import Bracket, Match, Pool, PositionPool, SwissRound
+from server.tournament.utils import (
+    apply_bye,
+    get_new_pool_results,
+    recompute_swiss_ranks,
+    sort_swiss_tied_teams,
+    sort_tied_teams,
+)
 
 
 class SeedingUpdateResyncTests(ApiBaseTestCase):
@@ -176,3 +186,252 @@ class SeedingUpdateResyncSwissTests(ApiBaseTestCase):
             placeholder_seed_2=8,
         )
         self.assertEqual(match.team_1_id, original_seed_2_team)
+
+
+class PoolThreeWayTieBreakTests(ApiBaseTestCase):
+    """WFDF restart: once a criterion separates teams, remaining ties restart at H2H."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.team_a, self.team_b, self.team_c, self.team_d = self.teams[:4]
+        self.pool = Pool.objects.create(
+            name="A",
+            tournament=self.tournament,
+            sequence_number=1,
+            initial_seeding={
+                1: self.team_a.id,
+                2: self.team_b.id,
+                3: self.team_c.id,
+                4: self.team_d.id,
+            },
+            results={},
+        )
+
+    def _play(self, team_1: Team, team_2: Team, score_1: int, score_2: int, **kwargs: Any) -> Match:
+        return Match.objects.create(
+            tournament=self.tournament,
+            team_1=team_1,
+            team_2=team_2,
+            score_team_1=score_1,
+            score_team_2=score_2,
+            status=Match.Status.COMPLETED,
+            sequence_number=1,
+            placeholder_seed_1=1,
+            placeholder_seed_2=2,
+            **kwargs,
+        )
+
+    def _run_pool(self, matches: list[Match]) -> tuple[dict[int, dict[str, int]], dict[int, int]]:
+        results = {
+            team.id: {"wins": 0, "losses": 0, "draws": 0, "GF": 0, "GA": 0}
+            for team in (self.team_a, self.team_b, self.team_c, self.team_d)
+        }
+        seeding = {1: 0, 2: 0, 3: 0, 4: 0}
+        for match in matches:
+            results, seeding = get_new_pool_results(results, match, [1, 2, 3, 4], seeding)
+        return results, seeding
+
+    def test_three_way_tie_restarts_at_head_to_head(self) -> None:
+        """A/B/C cycle with equal H2H GD; overall GD separates A; then C>B by H2H.
+
+        The old single-pass sort left B ahead of C (input order) because
+        every remaining criterion was equal; WFDF requires restarting at
+        head-to-head between B and C, which C won.
+        """
+        matches = [
+            self._play(self.team_a, self.team_b, 10, 15, pool=self.pool),  # B beats A
+            self._play(self.team_b, self.team_c, 10, 15, pool=self.pool),  # C beats B
+            self._play(self.team_c, self.team_a, 10, 15, pool=self.pool),  # A beats C
+            self._play(self.team_a, self.team_d, 15, 5, pool=self.pool),  # A +10
+            self._play(self.team_b, self.team_d, 15, 10, pool=self.pool),  # B +5
+            self._play(self.team_c, self.team_d, 15, 10, pool=self.pool),  # C +5
+        ]
+        results, seeding = self._run_pool(matches)
+
+        self.assertEqual(results[self.team_a.id]["rank"], 1)  # best overall GD
+        self.assertEqual(results[self.team_c.id]["rank"], 2)  # beat B head-to-head
+        self.assertEqual(results[self.team_b.id]["rank"], 3)
+        self.assertEqual(results[self.team_d.id]["rank"], 4)
+        self.assertEqual(seeding[2], self.team_c.id)
+
+    def test_head_to_head_ignores_matches_from_other_stages(self) -> None:
+        """A bracket game between two pool-tied teams must not affect pool ranks."""
+        # Pool: A beats B and D, loses to C; B beats C and D, loses to A.
+        matches = [
+            self._play(self.team_a, self.team_b, 15, 14, pool=self.pool),
+            self._play(self.team_c, self.team_a, 15, 10, pool=self.pool),
+            self._play(self.team_a, self.team_d, 15, 10, pool=self.pool),
+            self._play(self.team_b, self.team_c, 15, 10, pool=self.pool),
+            self._play(self.team_b, self.team_d, 15, 10, pool=self.pool),
+            self._play(self.team_d, self.team_c, 15, 10, pool=self.pool),
+        ]
+        # Same-tournament bracket game where B crushed A. If it leaked into the
+        # pool tie-break, B would jump ahead of A.
+        bracket = Bracket.objects.create(
+            name="1-4",
+            tournament=self.tournament,
+            sequence_number=1,
+            initial_seeding={1: 0, 2: 0, 3: 0, 4: 0},
+            current_seeding={1: 0, 2: 0, 3: 0, 4: 0},
+        )
+        self._play(self.team_a, self.team_b, 0, 15, bracket=bracket)
+
+        results, _ = self._run_pool(matches)
+
+        self.assertEqual(results[self.team_a.id]["rank"], 1)  # won pool H2H vs B
+        self.assertEqual(results[self.team_b.id]["rank"], 2)
+        self.assertEqual(results[self.team_d.id]["rank"], 3)  # won pool H2H vs C
+        self.assertEqual(results[self.team_c.id]["rank"], 4)
+
+    def test_position_pool_head_to_head_ignores_pool_games(self) -> None:
+        """Position pool ties must only count position pool games."""
+        position_pool = PositionPool.objects.create(
+            name="E",
+            tournament=self.tournament,
+            sequence_number=1,
+            initial_seeding={5: 0, 6: 0, 7: 0},
+            results={},
+        )
+        # Earlier pool game: C thrashed B. Must not leak into position pool.
+        self._play(self.team_c, self.team_b, 15, 0, pool=self.pool)
+
+        pp_matches = [
+            # Cycle: A beats B (+1), B beats C (+5), C beats A (+2)
+            self._play(self.team_a, self.team_b, 15, 14, position_pool=position_pool),
+            self._play(self.team_b, self.team_c, 15, 10, position_pool=position_pool),
+            self._play(self.team_c, self.team_a, 15, 13, position_pool=position_pool),
+        ]
+        results = {
+            team.id: {"wins": 0, "losses": 0, "draws": 0, "GF": 0, "GA": 0}
+            for team in (self.team_a, self.team_b, self.team_c)
+        }
+        seeding = {5: 0, 6: 0, 7: 0}
+        for match in pp_matches:
+            results, seeding = get_new_pool_results(results, match, [5, 6, 7], seeding)
+
+        # H2H GD within the position pool only: B +4, A -1, C -3
+        self.assertEqual(results[self.team_b.id]["rank"], 1)
+        self.assertEqual(results[self.team_a.id]["rank"], 2)
+        self.assertEqual(results[self.team_c.id]["rank"], 3)
+
+    def test_sort_tied_teams_fully_tied_group_keeps_order(self) -> None:
+        tied = [
+            {"id": self.team_a.id, "GF": 30, "GA": 30},
+            {"id": self.team_b.id, "GF": 30, "GA": 30},
+        ]
+        result = sort_tied_teams(tied, self.tournament.id, self.pool)
+        self.assertEqual([t["id"] for t in result], [self.team_a.id, self.team_b.id])
+
+
+class SwissTieBreakRestartTests(ApiBaseTestCase):
+    """Swiss ties must restart at H2H once a criterion separates the group."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.swiss_round = SwissRound.objects.create(
+            tournament=self.tournament,
+            name="A",
+            sequence_number=1,
+            num_rounds=4,
+            current_round=3,
+            initial_seeding={i + 1: self.teams[i].id for i in range(6)},
+            results={},
+            byes={},
+        )
+        self.team_a, self.team_b, self.team_c = self.teams[:3]
+        self.team_d, self.team_e, self.team_f = self.teams[3:6]
+
+    def _swiss_match(self, team_1: Team, team_2: Team, score_1: int, score_2: int) -> Match:
+        return Match.objects.create(
+            tournament=self.tournament,
+            swiss_round=self.swiss_round,
+            team_1=team_1,
+            team_2=team_2,
+            score_team_1=score_1,
+            score_team_2=score_2,
+            status=Match.Status.COMPLETED,
+            sequence_number=1,
+            placeholder_seed_1=1,
+            placeholder_seed_2=2,
+        )
+
+    def test_restart_uses_head_to_head_after_opp_strength_separates(self) -> None:
+        """Cycle A>B>C>A; A faced stronger opponents; then B beat C directly.
+
+        Old behaviour ordered the B/C remainder by goal difference (C ahead);
+        WFDF restart puts B ahead because B won the head-to-head.
+        """
+        # The A/B/C cycle
+        self._swiss_match(self.team_a, self.team_b, 15, 10)
+        self._swiss_match(self.team_b, self.team_c, 15, 10)
+        self._swiss_match(self.team_c, self.team_a, 15, 10)
+        # Extra games defining opponent strength: A played D (strong),
+        # B played E (weak), C played F (weak).
+        self._swiss_match(self.team_a, self.team_d, 15, 10)
+        self._swiss_match(self.team_b, self.team_e, 15, 10)
+        self._swiss_match(self.team_c, self.team_f, 15, 10)
+
+        all_results = {
+            self.team_a.id: {"wins": 2, "draws": 0, "losses": 1, "GF": 40, "GA": 35},
+            self.team_b.id: {"wins": 2, "draws": 0, "losses": 1, "GF": 40, "GA": 38},
+            # C gets the best goal difference so the old sort would rank C > B
+            self.team_c.id: {"wins": 2, "draws": 0, "losses": 1, "GF": 45, "GA": 30},
+            self.team_d.id: {"wins": 3, "draws": 0, "losses": 1, "GF": 60, "GA": 40},
+            self.team_e.id: {"wins": 0, "draws": 0, "losses": 3, "GF": 20, "GA": 45},
+            self.team_f.id: {"wins": 0, "draws": 0, "losses": 3, "GF": 20, "GA": 45},
+        }
+        tied = [
+            {"id": self.team_c.id, **all_results[self.team_c.id]},
+            {"id": self.team_b.id, **all_results[self.team_b.id]},
+            {"id": self.team_a.id, **all_results[self.team_a.id]},
+        ]
+
+        result = sort_swiss_tied_teams(tied, all_results, self.swiss_round)
+
+        self.assertEqual(
+            [t["id"] for t in result],
+            [self.team_a.id, self.team_b.id, self.team_c.id],
+        )
+
+    def test_bye_reranks_with_swiss_tiebreakers(self) -> None:
+        """apply_bye must rank with H2H/opp-strength, not raw goal difference."""
+        self._swiss_match(self.team_a, self.team_b, 15, 13)
+
+        self.swiss_round.initial_seeding = {
+            1: self.team_a.id,
+            2: self.team_b.id,
+            3: self.team_c.id,
+        }
+        self.swiss_round.results = {
+            self.team_a.id: {"wins": 1, "draws": 0, "losses": 0, "GF": 15, "GA": 13},
+            self.team_b.id: {"wins": 1, "draws": 0, "losses": 0, "GF": 25, "GA": 15},
+            self.team_c.id: {"wins": 0, "draws": 0, "losses": 0, "GF": 0, "GA": 0},
+        }
+        self.swiss_round.save()
+        self.tournament.current_seeding = {
+            "1": self.team_a.id,
+            "2": self.team_b.id,
+            "3": self.team_c.id,
+        }
+        self.tournament.save()
+
+        # C's bye makes it 15-0 (GD +15) — best GD of the three, but C has
+        # no head-to-head wins and faced nobody, so C must rank last.
+        apply_bye(self.swiss_round, self.team_c.id, 2)
+
+        self.swiss_round.refresh_from_db()
+        results = {int(k): v for k, v in self.swiss_round.results.items()}
+        self.assertEqual(results[self.team_a.id]["rank"], 1)  # beat B head-to-head
+        self.assertEqual(results[self.team_b.id]["rank"], 2)
+        self.assertEqual(results[self.team_c.id]["rank"], 3)
+
+    def test_recompute_swiss_ranks_prefers_head_to_head_over_gd(self) -> None:
+        self._swiss_match(self.team_a, self.team_b, 15, 14)
+        results = {
+            self.team_a.id: {"wins": 1, "draws": 0, "losses": 0, "GF": 15, "GA": 14},
+            self.team_b.id: {"wins": 1, "draws": 0, "losses": 0, "GF": 30, "GA": 14},
+        }
+        seeding = {1: 0, 2: 0}
+        results, seeding = recompute_swiss_ranks(self.swiss_round, results, [1, 2], seeding)
+        self.assertEqual(results[self.team_a.id]["rank"], 1)
+        self.assertEqual(seeding[1], self.team_a.id)

--- a/server/tournament/utils.py
+++ b/server/tournament/utils.py
@@ -41,6 +41,76 @@ PLAYER_ROLE = "player"
 # Exported Functions ####################
 
 
+def update_tournament_seeding(
+    tournament: Tournament, seeding: dict[int, int]
+) -> tuple[bool, message_response | None]:
+    """Validate and apply a new tournament seeding before the tournament starts.
+
+    Pools and Swiss groups snapshot seed -> team_id (and per-team results) at
+    creation time. Re-syncing those snapshots here lets staff re-seed freely
+    at any point before the tournament starts, without having to delete and
+    recreate the whole structure. Matches only hold placeholder seeds until
+    the tournament starts, so they need no update.
+    """
+    if tournament.status in (Tournament.Status.LIVE, Tournament.Status.COMPLETED):
+        return False, {
+            "message": "Cannot update seeding after the tournament has started. "
+            "Match results drive the current seeding once the tournament is live."
+        }
+
+    valid_seeds_and_teams, errors = validate_seeds_and_teams(tournament, seeding)
+    if not valid_seeds_and_teams:
+        message = "Cannot update standings, due to following errors: \n"
+        message += "\n".join(f"{key}: {value}" for key, value in errors.items())
+        return False, {"message": message}
+
+    with transaction.atomic():
+        tournament.initial_seeding = dict(sorted(seeding.items()))
+        tournament.current_seeding = dict(sorted(seeding.items()))
+        tournament.save()
+
+        seed_to_team = {int(seed): team_id for seed, team_id in seeding.items()}
+
+        for pool in Pool.objects.filter(tournament=tournament):
+            new_seeding: dict[int, int] = {}
+            new_results: dict[int, dict[str, int]] = {}
+            for i, seed in enumerate(sorted(map(int, pool.initial_seeding.keys()))):
+                team_id = seed_to_team[seed]
+                new_seeding[seed] = team_id
+                new_results[team_id] = {
+                    "rank": i + 1,
+                    "wins": 0,
+                    "losses": 0,
+                    "draws": 0,
+                    "GF": 0,
+                    "GA": 0,
+                }
+            pool.initial_seeding = new_seeding
+            pool.results = new_results
+            pool.save()
+
+        for swiss_round in SwissRound.objects.filter(tournament=tournament):
+            new_swiss_seeding: dict[int, int] = {}
+            new_swiss_results: dict[str, dict[str, int]] = {}
+            for i, seed in enumerate(sorted(map(int, swiss_round.initial_seeding.keys()))):
+                team_id = seed_to_team[seed]
+                new_swiss_seeding[seed] = team_id
+                new_swiss_results[str(team_id)] = {
+                    "rank": i + 1,
+                    "wins": 0,
+                    "losses": 0,
+                    "draws": 0,
+                    "GF": 0,
+                    "GA": 0,
+                    "opp_strength": 0,
+                }
+            swiss_round.initial_seeding = new_swiss_seeding
+            swiss_round.results = new_swiss_results
+            swiss_round.save()
+
+    return True, None
+
+
 def create_pool_matches(tournament: Tournament, pool: Pool) -> None:
     pool_seeding_list = list(map(int, pool.initial_seeding.keys()))
 

--- a/server/tournament/utils.py
+++ b/server/tournament/utils.py
@@ -1955,6 +1955,52 @@ def validate_new_pool(
     return valid_pool, errors
 
 
+def validate_bracket_name(
+    tournament: Tournament, name: str
+) -> tuple[bool, message_response | None]:
+    """Bracket names must be seed ranges like '1-8' spanning an even seed count.
+
+    Odd-sized ranges would silently create no matches (create_bracket_matches
+    only handles even sizes), and non-numeric names crash seed parsing.
+    """
+    expected_parts = 2
+    parts = name.split("-")
+    if len(parts) != expected_parts or not all(part.isdigit() for part in parts):
+        return False, {"message": "Bracket name must be a seed range like '1-8' or '9-16'"}
+
+    start, end = int(parts[0]), int(parts[1])
+    if start < 1 or end <= start:
+        return False, {
+            "message": f"Bracket name '{name}' is not a valid seed range: "
+            "the first seed must be 1 or higher and lower than the last seed"
+        }
+
+    if ((end - start) + 1) % 2 != 0:
+        return False, {
+            "message": f"Bracket '{name}' spans an odd number of seeds "
+            f"({(end - start) + 1}); brackets need an even seed count. "
+            "Use a position pool for the leftover seeds instead."
+        }
+
+    # A bracket over seeds nobody holds produces matches that can never be
+    # filled, the same way validate_new_pool refuses out-of-range pool seeds.
+    num_teams = tournament.teams.all().count()
+    if end > num_teams:
+        return False, {
+            "message": f"Bracket '{name}' reaches seed {end}, but only {num_teams} "
+            f"{'team is' if num_teams == 1 else 'teams are'} registered for this "
+            "tournament"
+        }
+
+    # Last, because it is the least informative of the four: the name has to fit
+    # the column, and hitting the database to find that out is a 500.
+    max_length = Bracket._meta.get_field("name").max_length
+    if max_length is not None and len(name) > max_length:
+        return False, {"message": f"Bracket name '{name}' is longer than {max_length} characters"}
+
+    return True, None
+
+
 def get_bracket_match_name(start: int, end: int, seed_1: int, seed_2: int) -> str:
     """Get type of bracket match (Quarter Finals, Semi Finals, Finals, Position match)"""
 

--- a/server/tournament/utils.py
+++ b/server/tournament/utils.py
@@ -2,7 +2,8 @@ import contextlib
 import datetime
 import os
 from collections import Counter
-from typing import cast
+from collections.abc import Callable
+from typing import Any, cast
 
 from django.db import transaction
 from django.db.models import Q
@@ -198,24 +199,14 @@ def apply_bye(swiss_round: SwissRound, team_id: int, round_number: int) -> None:
     results[team_id]["wins"] += 1
     results[team_id]["GF"] += BYE_SCORE
 
-    # Re-rank all teams by points (win=2, draw=1)
-    results_list = sorted(
-        results.items(),
-        key=lambda item: (
-            item[1]["wins"] * 2 + item[1].get("draws", 0),
-            item[1]["GF"] - item[1]["GA"],
-            item[1]["GF"],
-        ),
-        reverse=True,
-    )
-
+    # Re-rank all teams by points (win=2, draw=1) with Swiss tiebreakers
     pool_seeding_list = sorted(map(int, swiss_round.initial_seeding.keys()))
     tournament = swiss_round.tournament
-    tournament_seeding = tournament.current_seeding
+    tournament_seeding = {int(k): v for k, v in tournament.current_seeding.items()}
 
-    for i, (tid, _stats) in enumerate(results_list):
-        results[tid]["rank"] = i + 1
-        tournament_seeding[pool_seeding_list[i]] = tid
+    results, tournament_seeding = recompute_swiss_ranks(
+        swiss_round, results, pool_seeding_list, tournament_seeding
+    )
 
     # Compute and store opponent strength (sum of opponents' points)
     all_swiss_matches = Match.objects.filter(swiss_round=swiss_round, status=Match.Status.COMPLETED)
@@ -324,19 +315,7 @@ def assign_swiss_round_teams(
         pairings = generate_swiss_pairings(swiss_round, exclude_team_id=bye_team_id)
 
         # Build team_id -> current rank map from results
-        results = swiss_round.results
-        ranked_teams = sorted(
-            results.items(),
-            key=lambda item: (
-                item[1]["wins"],
-                item[1]["GF"] - item[1]["GA"],
-                item[1]["GF"],
-            ),
-            reverse=True,
-        )
-        team_rank: dict[int, int] = {
-            int(tid): rank + 1 for rank, (tid, _) in enumerate(ranked_teams)
-        }
+        team_rank: dict[int, int] = swiss_team_rank_map(swiss_round.results)
 
         for i, (team_1_id, team_2_id) in enumerate(pairings):
             if i < len(round_matches):
@@ -566,27 +545,42 @@ def generate_swiss_pairings(
     return pairs
 
 
-def sort_tied_teams(tied_teams: list[dict[str, int]], tournament_id: int) -> list[dict[str, int]]:
+def sort_tied_teams(
+    tied_teams: list[dict[str, int]],
+    tournament_id: int,
+    stage: Pool | PositionPool | None = None,
+) -> list[dict[str, int]]:
+    """Order teams tied on pool wins, following the WFDF tie-break procedure.
+
+    Criteria, in order of precedence:
+    1. Games won counting only games between tied teams
+    2. Goal difference counting only games between tied teams
+    3. Goal difference counting all pool games
+    4. Goals scored counting only games between tied teams
+    5. Goals scored counting all pool games
+
+    Per WFDF, whenever a criterion separates the tied group into smaller
+    groups, the procedure restarts at criterion 1 within each remaining
+    tied sub-group (head-to-head stats are recomputed among only those
+    teams). Only games from the same stage (this pool / position pool)
+    count towards the head-to-head criteria.
     """
-    This is the comparator function for comparing pool results
-    The order of precedence is as follows:
-    1. Games won in pool
-    2. Games won counting only games between tied teams
-    3. Goal Difference only games between tied teams
-    4. Goal Difference counting all pool games
-    5. Goals Scored only games between tied teams
-    6. Goals Scored counting all pool games
-    """
+    if len(tied_teams) <= 1:
+        return list(tied_teams)
 
     team_stats: dict[int, dict[str, int]] = {
         team["id"]: {"wins": 0, "gd": 0, "gf": 0} for team in tied_teams
     }
 
-    # Get all matches between tied teams
+    # Get matches between tied teams, restricted to this stage's games
     team_ids = [team["id"] for team in tied_teams]
     matches = Match.objects.filter(
         tournament_id=tournament_id, status=Match.Status.COMPLETED
     ).filter(Q(team_1__id__in=team_ids, team_2__id__in=team_ids))
+    if isinstance(stage, Pool):
+        matches = matches.filter(pool=stage)
+    elif isinstance(stage, PositionPool):
+        matches = matches.filter(position_pool=stage)
 
     # Calculate head-to-head stats
     for match in matches:
@@ -605,18 +599,51 @@ def sort_tied_teams(tied_teams: list[dict[str, int]], tournament_id: int) -> lis
         team_stats[match.team_1.id]["gf"] += match.score_team_1
         team_stats[match.team_2.id]["gf"] += match.score_team_2
 
-    # Sort teams based on criteria
-    return sorted(
-        tied_teams,
-        key=lambda team: (
+    def criteria(team: dict[str, int]) -> tuple[int, int, int, int, int]:
+        return (
             team_stats[team["id"]]["wins"],  # 1. Head-to-head wins
             team_stats[team["id"]]["gd"],  # 2. Head-to-head goal difference
             team["GF"] - team["GA"],  # 3. Overall goal difference
             team_stats[team["id"]]["gf"],  # 4. Head-to-head goals scored
             team["GF"],  # 5. Overall goals scored
-        ),
-        reverse=True,
+        )
+
+    return _rank_by_criteria_with_restart(
+        tied_teams,
+        criteria,
+        lambda sub_group: sort_tied_teams(sub_group, tournament_id, stage),
     )
+
+
+def _rank_by_criteria_with_restart(
+    tied_teams: list[dict[str, int]],
+    criteria: Callable[[dict[str, int]], tuple[int, ...]],
+    restart: Callable[[list[dict[str, int]]], list[dict[str, int]]],
+) -> list[dict[str, int]]:
+    """Apply ordered tie-break criteria with the WFDF restart rule.
+
+    Finds the first criterion that separates the group, orders sub-groups by
+    that criterion, then restarts the full procedure within each sub-group
+    that is still tied. Returns the teams unchanged when no criterion can
+    separate them.
+    """
+    num_criteria = len(criteria(tied_teams[0]))
+    for index in range(num_criteria):
+        values = {criteria(team)[index] for team in tied_teams}
+        if len(values) == 1:
+            continue
+
+        ordered: list[dict[str, int]] = []
+        for value in sorted(values, reverse=True):
+            sub_group = [team for team in tied_teams if criteria(team)[index] == value]
+            if len(sub_group) > 1:
+                # Strictly smaller than tied_teams (values has >1 entry),
+                # so the restart always terminates.
+                sub_group = restart(sub_group)
+            ordered.extend(sub_group)
+        return ordered
+
+    return list(tied_teams)
 
 
 def sort_swiss_tied_teams(
@@ -631,9 +658,9 @@ def sort_swiss_tied_teams(
     2. Strength of opponents faced (sum of opponents' points — higher = stronger)
     3. Overall goal difference
 
-    When multiple teams share the same H2H win count, recursively
-    re-evaluate tiebreakers within that sub-group (smaller group means
-    different H2H dynamics).
+    Whenever a criterion separates the tied group, the procedure restarts
+    at criterion 1 within each remaining tied sub-group (smaller group
+    means different H2H dynamics).
     """
     if len(tied_teams) <= 1:
         return tied_teams
@@ -670,33 +697,74 @@ def sort_swiss_tied_teams(
                     "draws", 0
                 )
 
-    sorted_teams = sorted(
-        tied_teams,
-        key=lambda t: (
+    def criteria(t: dict[str, int]) -> tuple[int, ...]:
+        return (
             h2h_wins[t["id"]],  # 1. H2H wins (higher = better)
             opp_strength[t["id"]],  # 2. Opponent strength: higher = faced stronger
             t["GF"] - t["GA"],  # 3. Overall goal difference
+        )
+
+    # Whenever a criterion separates the group, restart the procedure within
+    # each remaining tied sub-group (H2H is recomputed among only those teams).
+    return _rank_by_criteria_with_restart(
+        tied_teams,
+        criteria,
+        lambda sub_group: sort_swiss_tied_teams(sub_group, all_results, swiss_round),
+    )
+
+
+def recompute_swiss_ranks(
+    swiss_round: SwissRound,
+    results: dict[int, dict[str, int]],
+    pool_seeding_list: list[int],
+    tournament_seeding: dict[int, int],
+) -> tuple[dict[int, dict[str, int]], dict[int, int]]:
+    """Assign ranks by points (win=2, draw=1) with Swiss tiebreakers.
+
+    Updates the given tournament seeding map so the group's seeds follow the
+    new rank order. This is the single source of truth for Swiss ranking —
+    byes, reruns and score updates must all rank teams the same way.
+    """
+    for tid in results:
+        results[tid]["id"] = tid
+
+    points_groups: dict[int, list[dict[str, int]]] = {}
+    for result in results.values():
+        points = result["wins"] * 2 + result.get("draws", 0)
+        points_groups.setdefault(points, []).append(result)
+
+    ranked: list[dict[str, int]] = []
+    for points in sorted(points_groups, reverse=True):
+        tied = points_groups[points]
+        if len(tied) == 1:
+            ranked.extend(tied)
+        else:
+            ranked.extend(sort_swiss_tied_teams(tied, results, swiss_round))
+
+    for i, result in enumerate(ranked):
+        results[result["id"]]["rank"] = i + 1
+        tournament_seeding[pool_seeding_list[i]] = int(result["id"])
+
+    return results, tournament_seeding
+
+
+def swiss_team_rank_map(results: dict[Any, dict[str, int]]) -> dict[int, int]:
+    """Team id -> current rank, preferring stored ranks over a raw points sort."""
+    normalized = {int(tid): stats for tid, stats in results.items()}
+    ranks = [stats.get("rank") for stats in normalized.values()]
+    if all(isinstance(rank, int) for rank in ranks) and len(set(ranks)) == len(ranks):
+        return {tid: stats["rank"] for tid, stats in normalized.items()}
+
+    ranked = sorted(
+        normalized.items(),
+        key=lambda item: (
+            item[1]["wins"] * 2 + item[1].get("draws", 0),
+            item[1]["GF"] - item[1]["GA"],
+            item[1]["GF"],
         ),
         reverse=True,
     )
-
-    # Recursively break sub-ties among teams with same H2H wins
-    final_order: list[dict[str, int]] = []
-    i = 0
-    while i < len(sorted_teams):
-        j = i + 1
-        while (
-            j < len(sorted_teams)
-            and h2h_wins[sorted_teams[j]["id"]] == h2h_wins[sorted_teams[i]["id"]]
-        ):
-            j += 1
-        sub_group = sorted_teams[i:j]
-        if len(sub_group) > 1 and len(sub_group) < len(tied_teams):
-            sub_group = sort_swiss_tied_teams(sub_group, all_results, swiss_round)
-        final_order.extend(sub_group)
-        i = j
-
-    return final_order
+    return {tid: i + 1 for i, (tid, _) in enumerate(ranked)}
 
 
 def get_new_pool_results(
@@ -745,8 +813,9 @@ def get_new_pool_results(
         if len(tied_teams) == 1:
             ranked_results.extend(tied_teams)
         else:
-            # Sort tied teams using head-to-head criteria
-            sorted_tied_teams = sort_tied_teams(tied_teams, match.tournament.id)
+            # Sort tied teams using head-to-head criteria within this stage
+            stage = match.pool or match.position_pool
+            sorted_tied_teams = sort_tied_teams(tied_teams, match.tournament.id, stage)
             ranked_results.extend(sorted_tied_teams)
 
     new_results = {}
@@ -898,28 +967,10 @@ def rerun_swiss_round(tournament: Tournament, swiss_round: SwissRound) -> None:
         pool_seeding_list: list[int],
     ) -> tuple[dict[int, dict[str, int]], dict[int, int]]:
         """Apply Swiss tiebreakers to assign ranks and update tournament seeding."""
-        for tid in results:
-            results[tid]["id"] = tid
-
-        points_groups: dict[int, list[dict[str, int]]] = {}
-        for result in results.values():
-            pts = result["wins"] * 2 + result.get("draws", 0)
-            points_groups.setdefault(pts, []).append(result)
-
-        ranked: list[dict[str, int]] = []
-        for pts in sorted(points_groups, reverse=True):
-            tied = points_groups[pts]
-            if len(tied) == 1:
-                ranked.extend(tied)
-            else:
-                ranked.extend(sort_swiss_tied_teams(tied, results, swiss_round))
-
         tournament_seeding_local = {int(k): v for k, v in tournament.current_seeding.items()}
-        for i, result in enumerate(ranked):
-            results[result["id"]]["rank"] = i + 1
-            tournament_seeding_local[pool_seeding_list[i]] = int(result["id"])
-
-        return results, tournament_seeding_local
+        return recompute_swiss_ranks(
+            swiss_round, results, pool_seeding_list, tournament_seeding_local
+        )
 
     def _recompute_opp_strength(results: dict[int, dict[str, int]]) -> None:
         """Recompute opponent strength (sum of opponents' points) for all teams."""
@@ -1028,16 +1079,7 @@ def rerun_swiss_round(tournament: Tournament, swiss_round: SwissRound) -> None:
     pairings = generate_swiss_pairings(swiss_round, exclude_team_id=bye_team_id_for_pairings)
 
     # Build rank map from current results
-    ranked_teams = sorted(
-        results.items(),
-        key=lambda item: (
-            item[1]["wins"],
-            item[1]["GF"] - item[1]["GA"],
-            item[1]["GF"],
-        ),
-        reverse=True,
-    )
-    team_rank: dict[int, int] = {int(tid): rank + 1 for rank, (tid, _) in enumerate(ranked_teams)}
+    team_rank: dict[int, int] = swiss_team_rank_map(results)
 
     for i, (t1_id, t2_id) in enumerate(pairings):
         if i < len(scheduled_matches):


### PR DESCRIPTION
Three fixes to tournament core, each its own commit:

- **Re-sync pool and Swiss snapshots on pre-start re-seeding.** Re-seeding
  before a tournament started left pool and Swiss snapshots holding the old
  teams, so the draw disagreed with the seeding.
- **Apply the WFDF restart rule to pool and Swiss tie-breaks.** When more
  than two teams are tied, teams that separate out are removed and the
  comparison restarts on the rest, per the championship appendix.
- **Validate bracket names before creating a bracket.** A malformed name
  produced a bracket whose matches could not be named.