### PR TITLE
frontend: Add the AI agent tournament manager tab

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -275,7 +275,7 @@ export default function App() {
                   <UserRoute
                     path="/tournament-manager"
                     component={TournamentManagerClassic}
-                    admin={true}
+                    staffOrDirector={true}
                   />
                   {/* <UserRoute
                     path="/tournament/:tournamentSlug/match/:matchId/edit-stats"

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -36,9 +36,7 @@ const Teams = lazy(() => import("./Teams"));
 const ViewTeam = lazy(() => import("./teams/View"));
 const EditTeam = lazy(() => import("./teams/Edit"));
 const CreateTeam = lazy(() => import("./teams/Create"));
-const TournamentManagerClassic = lazy(() =>
-  import("./tournament-manager/TournamentManagerClassic")
-);
+const TournamentManager = lazy(() => import("./TournamentManager"));
 const Tournaments = lazy(() => import("./Tournaments"));
 const Tournament = lazy(() => import("./Tournament"));
 const TeamRegistration = lazy(() => import("./TeamRegistration"));
@@ -274,7 +272,7 @@ export default function App() {
                   />
                   <UserRoute
                     path="/tournament-manager"
-                    component={TournamentManagerClassic}
+                    component={TournamentManager}
                     staffOrDirector={true}
                   />
                   {/* <UserRoute

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -36,7 +36,9 @@ const Teams = lazy(() => import("./Teams"));
 const ViewTeam = lazy(() => import("./teams/View"));
 const EditTeam = lazy(() => import("./teams/Edit"));
 const CreateTeam = lazy(() => import("./teams/Create"));
-const TournamentManager = lazy(() => import("./TournamentManager"));
+const TournamentManagerClassic = lazy(() =>
+  import("./tournament-manager/TournamentManagerClassic")
+);
 const Tournaments = lazy(() => import("./Tournaments"));
 const Tournament = lazy(() => import("./Tournament"));
 const TeamRegistration = lazy(() => import("./TeamRegistration"));
@@ -272,7 +274,7 @@ export default function App() {
                   />
                   <UserRoute
                     path="/tournament-manager"
-                    component={TournamentManager}
+                    component={TournamentManagerClassic}
                     admin={true}
                   />
                   {/* <UserRoute

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -510,6 +510,41 @@ const Dashboard = () => {
             </div>
           </div>
         </div>
+        <Show
+          when={
+            !store.data.is_staff &&
+            (store.data.directed_tournament_ids || []).length > 0
+          }
+        >
+          <h2 id="accordion-heading-director">
+            <button
+              type="button"
+              class="flex w-full items-center justify-between border-b border-gray-200 py-5 text-left font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400"
+              data-accordion-target="#accordion-body-director"
+              aria-expanded="false"
+              aria-controls="accordion-body-director"
+            >
+              <span>Tournament director</span>
+              <AccordionDownIcon />
+            </button>
+          </h2>
+          <div
+            id="accordion-body-director"
+            class="hidden"
+            aria-labelledby="accordion-heading-director"
+          >
+            <div class="border-b border-gray-200 py-5 dark:border-gray-700">
+              <div class="w-full text-sm font-medium text-gray-900 dark:text-white">
+                <A
+                  href="/tournament-manager"
+                  class="block w-full cursor-pointer border-b border-gray-200 px-4 py-2 hover:bg-gray-100 hover:text-blue-700 focus:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-700 dark:border-gray-600 dark:hover:bg-gray-600 dark:hover:text-white dark:focus:text-white dark:focus:ring-gray-500"
+                >
+                  Manage Tournament
+                </A>
+              </div>
+            </div>
+          </div>
+        </Show>
         <Show when={store.data.is_staff}>
           <h2 id="accordion-heading-staff">
             <button

--- a/frontend/src/components/StyledMarkdown.js
+++ b/frontend/src/components/StyledMarkdown.js
@@ -1,40 +1,48 @@
 import remarkGfm from "remark-gfm";
 import slug from "slug";
-import { onMount } from "solid-js";
+import { createEffect } from "solid-js";
 import SolidMarkdown from "solid-markdown";
+
+/** Page styling: headings are centered section titles (rules, help, about). */
+export const documentClassMap = {
+  a: "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline",
+  p: "mb-2",
+  h1: "text-2xl font-bold mb-4 text-blue-500 text-center",
+  h2: "text-xl font-bold mb-4 text-blue-500 text-center",
+  h3: "text-lg font-bold mb-4 underline",
+  ol: "m-4 text-gray-500 list-decimal list-outside dark:text-gray-400",
+  ul: "m-4 text-gray-500 list-disc list-outside dark:text-gray-400",
+  table:
+    "w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400 mb-5",
+  thead:
+    "text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400",
+  th: "px-6 py-3",
+  "tbody tr": "bg-white border-b dark:bg-gray-800 dark:border-gray-700",
+  "tbody td": "px-6 py-4 font-medium"
+};
 
 const TailwindMarkdown = props => {
   let divRef;
+  const classMap = () => props.classMap || documentClassMap;
 
-  const classMap = {
-    a: "font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline",
-    p: "mb-2",
-    h1: "text-2xl font-bold mb-4 text-blue-500 text-center",
-    h2: "text-xl font-bold mb-4 text-blue-500 text-center",
-    h3: "text-lg font-bold mb-4 underline",
-    ol: "m-4 text-gray-500 list-decimal list-outside dark:text-gray-400",
-    ul: "m-4 text-gray-500 list-disc list-outside dark:text-gray-400",
-    table:
-      "w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400 mb-5",
-    thead:
-      "text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400",
-    th: "px-6 py-3",
-    "tbody tr": "bg-white border-b dark:bg-gray-800 dark:border-gray-700",
-    "tbody td": "px-6 py-4 font-medium"
-  };
+  // An effect, not onMount: streamed replies swap these nodes out as tokens
+  // arrive, and anything rendered after mount would otherwise go unstyled.
+  createEffect(() => {
+    props.markdown;
+    const map = classMap();
+    if (!divRef) return;
 
-  onMount(() => {
-    // Add CSS classes
-    for (let tag in classMap) {
+    for (const tag in map) {
       divRef.querySelectorAll(tag).forEach(el => {
-        el.setAttribute("class", classMap[tag]);
+        el.setAttribute("class", map[tag]);
       });
     }
 
-    // Add ids to h1 tags
-    divRef.querySelectorAll("h1").forEach(el => {
-      el.setAttribute("id", slug(el.innerText));
-    });
+    if (props.headingIds !== false) {
+      divRef.querySelectorAll("h1").forEach(el => {
+        el.setAttribute("id", slug(el.innerText));
+      });
+    }
   });
 
   return (

--- a/frontend/src/components/TournamentManager.js
+++ b/frontend/src/components/TournamentManager.js
@@ -1,0 +1,85 @@
+import { createQuery } from "@tanstack/solid-query";
+import { createEffect, createMemo, createSignal, Show } from "solid-js";
+
+import { fetchTournaments } from "../queries";
+import TournamentAgentTab from "./tournament-manager/agent/TournamentAgentTab";
+import TournamentManagerClassic from "./tournament-manager/TournamentManagerClassic";
+
+/**
+ * Underline tabs — Flowbite MCP `flowbite://components/tabs` (Tabs with underline),
+ * mapped to this project's classic Flowbite/Tailwind tokens.
+ */
+const TournamentManager = () => {
+  const [tab, setTab] = createSignal("classic");
+  const [selectedTournamentId, setSelectedTournamentId] = createSignal(null);
+
+  const tournamentsQuery = createQuery(() => ["tournaments"], fetchTournaments);
+  const selectedTournament = createMemo(() =>
+    (tournamentsQuery.data || []).find(t => t.id === selectedTournamentId())
+  );
+  // Draft events stay on Classic only; the agent is for Scheduling and later.
+  const agentAvailable = () => selectedTournament()?.status !== "DFT";
+
+  createEffect(() => {
+    if (!agentAvailable() && tab() === "agent") setTab("classic");
+  });
+
+  const tabClass = active =>
+    active
+      ? "inline-block rounded-t-lg border-b-2 border-blue-600 p-4 text-blue-600 dark:border-blue-500 dark:text-blue-500"
+      : "inline-block rounded-t-lg border-b-2 border-transparent p-4 hover:border-gray-300 hover:text-gray-600 dark:hover:text-gray-300";
+
+  return (
+    <div
+      class={
+        tab() === "agent"
+          ? "flex h-[calc(100dvh-9.5rem)] flex-col overflow-hidden lg:h-[calc(100dvh-13.5rem)]"
+          : undefined
+      }
+    >
+      <Show when={agentAvailable()}>
+        <div class="mb-4 shrink-0 border-b border-gray-200 text-center text-sm font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400">
+          <ul class="-mb-px flex flex-wrap">
+            <li class="me-2">
+              <button
+                type="button"
+                class={tabClass(tab() === "classic")}
+                aria-current={tab() === "classic" ? "page" : undefined}
+                onClick={() => setTab("classic")}
+              >
+                Classic
+              </button>
+            </li>
+            <li class="me-2">
+              <button
+                type="button"
+                class={tabClass(tab() === "agent")}
+                aria-current={tab() === "agent" ? "page" : undefined}
+                onClick={() => setTab("agent")}
+              >
+                AI Agent
+              </button>
+            </li>
+          </ul>
+        </div>
+      </Show>
+
+      <Show when={tab() === "classic"}>
+        <TournamentManagerClassic
+          tournamentId={selectedTournamentId()}
+          onTournamentSelected={id => setSelectedTournamentId(id)}
+        />
+      </Show>
+      <Show when={tab() === "agent"}>
+        <div class="min-h-0 flex-1 overflow-hidden">
+          <TournamentAgentTab
+            tournamentId={selectedTournamentId()}
+            onSelectTournament={id => setSelectedTournamentId(id)}
+          />
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default TournamentManager;

--- a/frontend/src/components/UserRoute.js
+++ b/frontend/src/components/UserRoute.js
@@ -11,7 +11,7 @@ import {
 
 import { Spinner } from "../icons";
 import { useStore } from "../store";
-import { fetchUserData } from "../utils";
+import { canManageTournaments, fetchUserData } from "../utils";
 
 const WithUserData = props => {
   const [store, { userFetchSuccess, userFetchFailure }] = useStore();
@@ -32,12 +32,13 @@ const WithUserData = props => {
   });
 
   const canView = () => {
-    if (!props.admin) {
-      console.log(props.admin);
-      return true;
-    } else {
-      return store.userFetched && store?.data?.is_staff;
+    if (props.staffOrDirector) {
+      return store.userFetched && canManageTournaments(store?.data);
     }
+    if (!props.admin) {
+      return true;
+    }
+    return store.userFetched && store?.data?.is_staff;
   };
 
   return (
@@ -58,7 +59,7 @@ const WithUserData = props => {
           }
         >
           <p class="my-12 text-lg text-gray-500 md:text-xl lg:text-2xl">
-            Sorry, the page you want to view is only available to admins
+            Sorry, you do not have access to this page
           </p>
         </Match>
         <Match when={fetch() || (store.userFetched && !store?.data?.username)}>
@@ -76,7 +77,12 @@ const UserRoute = props => {
         {...props}
         component={null}
         element={
-          <WithUserData admin={props.admin}>{props.element}</WithUserData>
+          <WithUserData
+            admin={props.admin}
+            staffOrDirector={props.staffOrDirector}
+          >
+            {props.element}
+          </WithUserData>
         }
       />
     );
@@ -86,7 +92,10 @@ const UserRoute = props => {
         {...props}
         component={null}
         element={
-          <WithUserData admin={props.admin}>
+          <WithUserData
+            admin={props.admin}
+            staffOrDirector={props.staffOrDirector}
+          >
             <props.component />
           </WithUserData>
         }

--- a/frontend/src/components/match/MatchCard.js
+++ b/frontend/src/components/match/MatchCard.js
@@ -126,6 +126,7 @@ const TournamentMatch = props => {
       userAccessQuery.data &&
       (userAccessQuery.data.is_staff ||
         userAccessQuery.data.is_tournament_admin ||
+        userAccessQuery.data.is_tournament_director ||
         userAccessQuery.data.is_tournament_volunteer)
     );
   };

--- a/frontend/src/components/tournament-manager/CreatedFields.js
+++ b/frontend/src/components/tournament-manager/CreatedFields.js
@@ -124,6 +124,7 @@ const CreatedFields = props => {
   const [editingField, setEditingField] = createSignal();
   const [editStatus, setEditStatus] = createSignal("");
   const [secsLeftToClose, setSecsLeftToClose] = createSignal(closeDelaySec);
+  const [deleteError, setDeleteError] = createSignal("");
 
   // Directly using props.fields breaks the dialog's focus
   // when focus comes back to the page,
@@ -177,6 +178,25 @@ const CreatedFields = props => {
     });
   }
 
+  function handleDeleteClick(field) {
+    setDeleteError("");
+    if (
+      !window.confirm(
+        `Delete field "${field.name}"? Matches must already be moved off it.`
+      )
+    ) {
+      return;
+    }
+    props.deleteFieldMutation.mutate(
+      { field_id: field.id },
+      {
+        onError: error => {
+          setDeleteError(error.message);
+        }
+      }
+    );
+  }
+
   // the modal is closed with a delay once the mutation completes
   createEffect(function onMutationComplete() {
     if (props.updateFieldMutation.isSuccess) {
@@ -198,14 +218,24 @@ const CreatedFields = props => {
             <div class="relative overflow-x-auto rounded-md">
               <div class="flex w-full items-center justify-between bg-gray-300 p-4 text-left text-lg font-semibold text-gray-900 rtl:text-right dark:bg-gray-700 dark:text-white">
                 <span>{field.name}</span>
-                <button
-                  type="button"
-                  class="rounded-lg bg-yellow-400 px-4 py-1.5 text-sm font-medium text-white hover:bg-yellow-500 focus:outline-none focus:ring-4 focus:ring-yellow-300 disabled:bg-gray-400 dark:text-gray-800 dark:focus:ring-yellow-500 disabled:dark:bg-gray-400"
-                  onClick={() => handleEditClick(field)}
-                  disabled={props.editingDisabled}
-                >
-                  Edit
-                </button>
+                <div class="flex items-center gap-2">
+                  <button
+                    type="button"
+                    class="rounded-lg bg-yellow-400 px-4 py-1.5 text-sm font-medium text-white hover:bg-yellow-500 focus:outline-none focus:ring-4 focus:ring-yellow-300 disabled:bg-gray-400 dark:text-gray-800 dark:focus:ring-yellow-500 disabled:dark:bg-gray-400"
+                    onClick={() => handleEditClick(field)}
+                    disabled={props.editingDisabled}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    class="rounded-lg bg-red-700 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-800 focus:outline-none focus:ring-4 focus:ring-red-300 disabled:bg-gray-400 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-800 disabled:dark:bg-gray-400"
+                    onClick={() => handleDeleteClick(field)}
+                    disabled={props.editingDisabled}
+                  >
+                    Delete
+                  </button>
+                </div>
               </div>
               <table class="w-full text-left text-sm text-gray-500 dark:text-gray-400">
                 <tbody>
@@ -238,6 +268,11 @@ const CreatedFields = props => {
           </div>
         )}
       </For>
+      <Show when={deleteError()}>
+        <p class="col-span-3 text-sm text-red-700 dark:text-red-400">
+          {deleteError()}
+        </p>
+      </Show>
       <Modal
         ref={modalRef}
         close={handleEditClose}

--- a/frontend/src/components/tournament-manager/TournamentDirectors.js
+++ b/frontend/src/components/tournament-manager/TournamentDirectors.js
@@ -1,0 +1,138 @@
+import {
+  createMutation,
+  createQuery,
+  useQueryClient
+} from "@tanstack/solid-query";
+import { createSignal, For, Show } from "solid-js";
+
+import {
+  addTournamentDirector,
+  fetchTournamentDirectors,
+  removeTournamentDirector,
+  searchUsers
+} from "../../queries";
+
+const TournamentDirectors = props => {
+  const queryClient = useQueryClient();
+  const [searchText, setSearchText] = createSignal("");
+  const [selectedUserId, setSelectedUserId] = createSignal("");
+  const [error, setError] = createSignal("");
+
+  const directorsQuery = createQuery({
+    queryKey: () => ["tournament-directors", props.tournamentId],
+    queryFn: () => fetchTournamentDirectors(props.tournamentId),
+    get enabled() {
+      return Boolean(props.tournamentId);
+    }
+  });
+
+  const usersQuery = createQuery({
+    queryKey: () => ["users", "search", searchText()],
+    queryFn: () => searchUsers(searchText()),
+    get enabled() {
+      return searchText().trim().length > 0;
+    }
+  });
+
+  const addMutation = createMutation({
+    mutationFn: addTournamentDirector,
+    onSuccess: () => {
+      setError("");
+      setSelectedUserId("");
+      setSearchText("");
+      queryClient.invalidateQueries({
+        queryKey: ["tournament-directors", props.tournamentId]
+      });
+    },
+    onError: e => setError(e.message)
+  });
+
+  const removeMutation = createMutation({
+    mutationFn: removeTournamentDirector,
+    onSuccess: () => {
+      setError("");
+      queryClient.invalidateQueries({
+        queryKey: ["tournament-directors", props.tournamentId]
+      });
+    },
+    onError: e => setError(e.message)
+  });
+
+  return (
+    <div class="my-6 rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+      <h2 class="mb-3 text-xl font-bold text-blue-500">Tournament directors</h2>
+      <p class="mb-3 text-sm text-gray-600 dark:text-gray-400">
+        Directors can manage this tournament and use the AI agent. They cannot
+        create or delete tournaments, or appoint other directors.
+      </p>
+      <Show when={directorsQuery.data?.length}>
+        <ul class="mb-4 space-y-2">
+          <For each={directorsQuery.data}>
+            {user => (
+              <li class="flex items-center justify-between text-sm">
+                <span>
+                  {user.full_name || user.username}{" "}
+                  <span class="text-gray-500">({user.username})</span>
+                </span>
+                <button
+                  type="button"
+                  class="rounded-lg bg-red-700 px-3 py-1 text-xs font-medium text-white hover:bg-red-800"
+                  disabled={removeMutation.isLoading}
+                  onClick={() =>
+                    removeMutation.mutate({
+                      tournamentId: props.tournamentId,
+                      userId: user.id
+                    })
+                  }
+                >
+                  Remove
+                </button>
+              </li>
+            )}
+          </For>
+        </ul>
+      </Show>
+      <div class="grid gap-3 md:grid-cols-2">
+        <input
+          type="text"
+          value={searchText()}
+          onInput={e => setSearchText(e.target.value)}
+          placeholder="Search by name or username"
+          class="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+        />
+        <select
+          value={selectedUserId()}
+          onChange={e => setSelectedUserId(e.target.value)}
+          class="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+        >
+          <option value="">Select a user</option>
+          <For each={usersQuery.data || []}>
+            {user => (
+              <option value={user.id}>
+                {user.full_name || user.username} ({user.username})
+              </option>
+            )}
+          </For>
+        </select>
+      </div>
+      <button
+        type="button"
+        class="mt-3 rounded-lg bg-blue-700 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-800 disabled:bg-gray-400"
+        disabled={!selectedUserId() || addMutation.isLoading}
+        onClick={() =>
+          addMutation.mutate({
+            tournamentId: props.tournamentId,
+            userId: parseInt(selectedUserId(), 10)
+          })
+        }
+      >
+        Add director
+      </button>
+      <Show when={error()}>
+        <p class="mt-2 text-sm text-red-600">{error()}</p>
+      </Show>
+    </div>
+  );
+};
+
+export default TournamentDirectors;

--- a/frontend/src/components/tournament-manager/TournamentManagerClassic.js
+++ b/frontend/src/components/tournament-manager/TournamentManagerClassic.js
@@ -26,6 +26,7 @@ import {
   createPool,
   createPositionPool,
   createSwissRound,
+  deleteField,
   deleteMatch,
   fetchBrackets,
   fetchCrossPool,
@@ -42,18 +43,23 @@ import {
   updateField,
   updateMatch,
   updateSeeding
-} from "../queries";
-import ScheduleSkeleton from "../skeletons/Schedule";
-import { useStore } from "../store";
-import { getCookie } from "../utils";
-import MatchHeader from "./match/MatchHeader";
-import CreateTournamentForm from "./tournament/CreateTournamentForm";
-import ReorderTeams from "./tournament/ReorderTeams";
-import RulesMarkdownEditor from "./tournament/RulesMarkdownEditor";
-import ScheduleTable from "./tournament/ScheduleTable";
-import UpdateSpiritScoreForm from "./tournament/UpdateSpiritScoreForm";
-import CreatedFields from "./tournament-manager/CreatedFields";
-import CreateFieldForm from "./tournament-manager/CreateFieldForm";
+} from "../../queries";
+import ScheduleSkeleton from "../../skeletons/Schedule";
+import { useStore } from "../../store";
+import {
+  canManageTournaments,
+  filterManageableTournaments,
+  getCookie
+} from "../../utils";
+import MatchHeader from "../match/MatchHeader";
+import CreateTournamentForm from "../tournament/CreateTournamentForm";
+import ReorderTeams from "../tournament/ReorderTeams";
+import RulesMarkdownEditor from "../tournament/RulesMarkdownEditor";
+import ScheduleTable from "../tournament/ScheduleTable";
+import UpdateSpiritScoreForm from "../tournament/UpdateSpiritScoreForm";
+import CreatedFields from "./CreatedFields";
+import CreateFieldForm from "./CreateFieldForm";
+import TournamentDirectors from "./TournamentDirectors";
 
 function getMatchCsvLabel(match) {
   if (match.pool || match.position_pool) {
@@ -156,11 +162,13 @@ function downloadScheduleCsv(matches, fields, tournamentName) {
   URL.revokeObjectURL(url);
 }
 
-const TournamentManager = () => {
+const TournamentManager = props => {
   const queryClient = useQueryClient();
   const [store] = useStore();
   const [selectedTournament, setSelectedTournament] = createSignal();
-  const [selectedTournamentID, setSelectedTournamentID] = createSignal(0);
+  const [selectedTournamentID, setSelectedTournamentID] = createSignal(
+    props.tournamentId || 0
+  );
   const [teams, setTeams] = createSignal([]);
   const [teamsMap, setTeamsMap] = createSignal({});
   const [enteredPoolName, setEnteredPoolName] = createSignal("");
@@ -187,6 +195,9 @@ const TournamentManager = () => {
   const [scheduleFile, setScheduleFile] = createSignal(null);
   const [uploadError, setUploadError] = createSignal("");
 
+  // Classic only lets staff set up a tournament once it is Scheduling.
+  const canEditSetup = () => selectedTournament()?.status === "SCH";
+
   onMount(() => {
     const dt = new Date(1970, 0, 1, 6, 0);
     let newTimesList = [];
@@ -197,6 +208,10 @@ const TournamentManager = () => {
       dt.setMinutes(dt.getMinutes() + 5);
     }
     setTimesList(newTimesList);
+  });
+
+  createEffect(() => {
+    if (props.tournamentId) setSelectedTournamentID(props.tournamentId);
   });
 
   createEffect(() => {
@@ -286,6 +301,8 @@ const TournamentManager = () => {
 
   const teamsQuery = createQuery(() => ["teams"], fetchTeams);
   const tournamentsQuery = createQuery(() => ["tournaments"], fetchTournaments);
+  const manageableTournaments = () =>
+    filterManageableTournaments(tournamentsQuery.data, store?.data);
 
   const fieldsQuery = createQuery(
     () => ["fields", selectedTournamentID()],
@@ -372,6 +389,18 @@ const TournamentManager = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["fields", selectedTournamentID()]
+      });
+    }
+  });
+
+  const deleteFieldMutation = createMutation({
+    mutationFn: deleteField,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["fields", selectedTournamentID()]
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["matches", selectedTournamentID()]
       });
     }
   });
@@ -565,37 +594,48 @@ const TournamentManager = () => {
   };
 
   return (
-    <Show when={store?.data?.is_staff} fallback={<p>Not Authorised!</p>}>
-      <div>
-        <h1 class="text-center text-2xl font-bold text-blue-500">
-          New Tournament
-        </h1>
-        <CreateTournamentForm />
-        {/* <CreateTournamentFromEventForm />  // Can be added only when needed  */}
-      </div>
-      <hr class="my-8 h-px border-0 bg-gray-200 dark:bg-gray-700" />
+    <Show
+      when={canManageTournaments(store?.data)}
+      fallback={<p>Not Authorised!</p>}
+    >
+      <Show when={store?.data?.is_staff}>
+        <div>
+          <h1 class="text-center text-2xl font-bold text-blue-500">
+            New Tournament
+          </h1>
+          <CreateTournamentForm />
+          {/* <CreateTournamentFromEventForm />  // Can be added only when needed  */}
+        </div>
+        <hr class="my-8 h-px border-0 bg-gray-200 dark:bg-gray-700" />
+      </Show>
       <div>
         <h1 class="mb-5 text-center text-2xl font-bold text-blue-500">
           Existing Tournaments
         </h1>
         <select
           id="tournaments"
-          onChange={e => setSelectedTournamentID(parseInt(e.target.value))}
+          value={selectedTournamentID()}
+          onChange={e => {
+            const id = parseInt(e.target.value);
+            setSelectedTournamentID(id);
+            props.onTournamentSelected?.(id || null);
+          }}
           class="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
         >
-          <option value={0} selected>
-            Choose a tournament
-          </option>
-          <For each={tournamentsQuery.data}>
+          <option value={0}>Choose a tournament</option>
+          <For each={manageableTournaments()}>
             {t => <option value={t.id}>{t.event.title}</option>}
           </For>
         </select>
 
         <Show when={selectedTournamentID() > 0 && selectedTournament()}>
+          <Show when={store?.data?.is_staff}>
+            <TournamentDirectors tournamentId={selectedTournamentID()} />
+          </Show>
           <div class="relative my-5 overflow-x-auto">
             <div class="mb-4 text-xl font-bold text-blue-500">Seeding</div>
             <Switch>
-              <Match when={selectedTournament()?.status === "SCH"}>
+              <Match when={canEditSetup()}>
                 <div class="w-full md:w-1/2">
                   <ReorderTeams
                     teams={teams()}
@@ -655,10 +695,7 @@ const TournamentManager = () => {
                 });
                 setIsStandingsEdited(false);
               }}
-              disabled={
-                selectedTournament()?.status !== "SCH" ||
-                updateSeedingMutation.isLoading
-              }
+              disabled={!canEditSetup() || updateSeedingMutation.isLoading}
               class="my-2 mb-2 mr-2 rounded-lg bg-blue-700 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-800 disabled:bg-gray-400 dark:bg-blue-600 dark:hover:bg-blue-700 disabled:dark:bg-gray-400"
             >
               <Show
@@ -819,8 +856,7 @@ const TournamentManager = () => {
                         })
                       }
                       disabled={
-                        selectedTournament()?.status !== "SCH" ||
-                        swissRoundsQuery.data?.length > 0
+                        !canEditSetup() || swissRoundsQuery.data?.length > 0
                       }
                       class="mb-2 mr-2 mt-5 rounded-lg bg-blue-700 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-800 disabled:bg-gray-400 dark:bg-blue-600 dark:hover:bg-blue-700 disabled:dark:bg-gray-400"
                     >
@@ -1005,7 +1041,7 @@ const TournamentManager = () => {
                         })
                       }
                       disabled={
-                        selectedTournament()?.status !== "SCH" ||
+                        !canEditSetup() ||
                         (poolsQuery.data?.length > 0 &&
                           !poolsQuery.data?.message)
                       }
@@ -1041,7 +1077,7 @@ const TournamentManager = () => {
                     tournament_id: selectedTournamentID()
                   })
                 }
-                disabled={selectedTournament()?.status !== "SCH"}
+                disabled={!canEditSetup()}
                 class="mb-2 mr-2 mt-5 rounded-lg bg-blue-700 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-800 disabled:bg-gray-400 dark:bg-blue-600 dark:hover:bg-blue-700 disabled:dark:bg-gray-400"
               >
                 Create Cross Pool
@@ -1113,7 +1149,7 @@ const TournamentManager = () => {
                         seq_num: bracketQuery.data.length + 1
                       })
                     }
-                    disabled={selectedTournament()?.status !== "SCH"}
+                    disabled={!canEditSetup()}
                     class="mb-2 mr-2 mt-5 rounded-lg bg-blue-700 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-800 disabled:bg-gray-400 dark:bg-blue-600 dark:hover:bg-blue-700 disabled:dark:bg-gray-400"
                   >
                     Create Bracket
@@ -1205,7 +1241,7 @@ const TournamentManager = () => {
                         seeding_list: enteredPositionPoolSeedingList()
                       })
                     }
-                    disabled={selectedTournament()?.status !== "SCH"}
+                    disabled={!canEditSetup()}
                     class="mb-2 mr-2 mt-5 rounded-lg bg-blue-700 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-800 disabled:bg-gray-400 dark:bg-blue-600 dark:hover:bg-blue-700 disabled:dark:bg-gray-400"
                   >
                     Create Position Pool
@@ -1227,9 +1263,11 @@ const TournamentManager = () => {
                     fields={fieldsQuery.data}
                     tournamentId={selectedTournamentID()}
                     updateFieldMutation={updateFieldMutation}
+                    deleteFieldMutation={deleteFieldMutation}
                     editingDisabled={
-                      selectedTournament()?.status !== "SCH" ||
-                      updateFieldMutation.isLoading
+                      !canEditSetup() ||
+                      updateFieldMutation.isLoading ||
+                      deleteFieldMutation.isLoading
                     }
                   />
                 </Match>
@@ -1239,10 +1277,7 @@ const TournamentManager = () => {
             <CreateFieldForm
               tournamentId={selectedTournamentID()}
               createFieldMutation={createFieldMutation}
-              disabled={
-                selectedTournament()?.status !== "SCH" ||
-                createFieldMutation.isLoading
-              }
+              disabled={!canEditSetup() || createFieldMutation.isLoading}
               alreadyPresentFields={fieldsQuery.data}
             />
           </div>
@@ -1411,7 +1446,7 @@ const TournamentManager = () => {
                       body: matchFields
                     });
                   }}
-                  disabled={selectedTournament()?.status !== "SCH"}
+                  disabled={!canEditSetup()}
                   class="mb-2 mr-2 rounded-lg bg-blue-700 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-800 disabled:bg-gray-400 dark:bg-blue-600 dark:hover:bg-blue-700 disabled:dark:bg-gray-400"
                 >
                   Add Match
@@ -2036,7 +2071,7 @@ const TournamentManager = () => {
             </For>
           </div>
           <Switch>
-            <Match when={selectedTournament()?.status === "SCH"}>
+            <Match when={canEditSetup()}>
               <button
                 type="button"
                 onClick={() =>

--- a/frontend/src/components/tournament-manager/agent/ModelPicker.js
+++ b/frontend/src/components/tournament-manager/agent/ModelPicker.js
@@ -1,0 +1,31 @@
+import { For } from "solid-js";
+
+/** Quiet chrome: a bare select that reads as a label until you touch it. */
+const ModelPicker = props => {
+  return (
+    <>
+      <label for="tournament-agent-model" class="sr-only">
+        Model
+      </label>
+      <select
+        id="tournament-agent-model"
+        class="cursor-pointer rounded-md border-0 bg-transparent px-1.5 py-1 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+        style={{ color: "var(--agent-ink-muted)" }}
+        value={props.value || ""}
+        disabled={props.disabled}
+        onChange={e => props.onChange?.(e.target.value)}
+      >
+        <For each={props.models || []}>
+          {m => (
+            <option value={m.id}>
+              {m.label}
+              {m.hint ? ` — ${m.hint}` : ""}
+            </option>
+          )}
+        </For>
+      </select>
+    </>
+  );
+};
+
+export default ModelPicker;

--- a/frontend/src/components/tournament-manager/agent/ProposalCard.js
+++ b/frontend/src/components/tournament-manager/agent/ProposalCard.js
@@ -1,0 +1,565 @@
+import { createSignal, For, Show } from "solid-js";
+
+import { Spinner } from "../../../icons";
+
+const TOOL_TITLES = {
+  propose_pool_stage: "Create pool stage",
+  propose_create_pool: "Create pool",
+  propose_create_swiss_round: "Create Swiss round",
+  propose_create_cross_pool: "Create cross pool",
+  propose_create_cross_pool_matches: "Create cross pool matches",
+  propose_create_bracket: "Create bracket",
+  propose_create_position_pool: "Create position pool",
+  propose_create_field: "Add field",
+  propose_update_field: "Update field",
+  propose_delete_field: "Delete field",
+  propose_update_seeding: "Update seeding",
+  propose_update_match: "Update match",
+  propose_update_match_seeds: "Update match seeds",
+  propose_delete_match: "Delete match",
+  propose_bulk_schedule: "Schedule matches",
+  propose_recommended_schedule: "Schedule matches",
+  propose_shift_schedule: "Shift schedule",
+  propose_match_score: "Record match result",
+  propose_spirit_scores: "Record spirit scores",
+  propose_delete_stage: "Delete stage",
+  propose_full_setup: null,
+  propose_start_tournament: "Start tournament",
+  propose_generate_fixtures: "Populate fixtures"
+};
+
+/** Destructive/irreversible proposals get a heavier confirm treatment. */
+const HIGH_IMPACT = new Set([
+  "propose_delete_match",
+  "propose_delete_stage",
+  "propose_delete_field",
+  "propose_match_score",
+  "propose_start_tournament",
+  "propose_update_seeding"
+]);
+
+/**
+ * The agent only ever handles player ids. The server resolves them on the way out
+ * and sends the names alongside the proposal, so this is a lookup, not a fetch.
+ */
+const PlayerName = props => (
+  <span>{props.names?.[String(props.id)] || `Player ${props.id}`}</span>
+);
+
+const Field = props => (
+  <div class="flex gap-2 text-xs">
+    <span class="w-20 shrink-0" style={{ color: "var(--agent-ink-muted)" }}>
+      {props.label}
+    </span>
+    <span class="min-w-0 flex-1" style={{ color: "var(--agent-ink)" }}>
+      {props.children}
+    </span>
+  </div>
+);
+
+const SeedList = props => (
+  <div class="flex flex-wrap gap-1">
+    <For each={props.seeds || []}>
+      {seed => (
+        <span
+          class="rounded px-1.5 py-0.5 text-[11px] font-medium tabular-nums"
+          style={{
+            "background-color": "var(--agent-user-chip)",
+            color: "var(--agent-ink)"
+          }}
+          title={props.teamName?.(seed)}
+        >
+          {seed}
+          <Show when={props.teamName?.(seed)}>
+            <span class="ml-1 font-normal opacity-70">
+              {props.teamName(seed)}
+            </span>
+          </Show>
+        </span>
+      )}
+    </For>
+  </div>
+);
+
+/**
+ * Human preview of a proposal payload, per tool. Falls back to the raw JSON
+ * disclosure for shapes without a bespoke view - staff should be able to check
+ * what they are confirming without reading JSON.
+ */
+/** Stages seeded straight from registration, where seed N really is that team.
+ *  Everywhere else (cross pool, brackets, position pools) a seed is a placeholder
+ *  for "whoever finishes Nth", so showing today's team name against it is wrong. */
+const REGISTRATION_SEEDED = new Set([
+  "propose_create_pool",
+  "propose_pool_stage",
+  "propose_create_swiss_round",
+  "propose_full_setup",
+  "propose_update_seeding"
+]);
+
+const ProposalPreview = props => {
+  const p = () => props.proposal.payload || {};
+  const tool = () => props.proposal.tool_name;
+  const teamName = seed =>
+    REGISTRATION_SEEDED.has(tool()) ? props.seedToTeamName?.(seed) : undefined;
+  const playerNames = () => props.proposal.player_names || {};
+
+  return (
+    <div class="space-y-1.5">
+      <Show when={tool() === "propose_create_pool"}>
+        <Field label="Pool">{p().name}</Field>
+        <Field label="Seeds">
+          <SeedList seeds={p().seeding} teamName={teamName} />
+        </Field>
+      </Show>
+
+      <Show when={tool() === "propose_pool_stage"}>
+        <Field label="Pools">{(p().pools || []).length}</Field>
+        <div class="space-y-1">
+          <For each={p().pools || []}>
+            {pool => (
+              <Field label={`Pool ${pool.name}`}>
+                <SeedList seeds={pool.seeding} teamName={teamName} />
+              </Field>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <Show when={tool() === "propose_create_swiss_round"}>
+        <Field label="Group">{p().name}</Field>
+        <Field label="Rounds">{p().num_rounds}</Field>
+        <Field label="Seeds">
+          <SeedList seeds={p().seeding} teamName={teamName} />
+        </Field>
+      </Show>
+
+      <Show when={tool() === "propose_create_bracket"}>
+        <Field label="Bracket">{p().name}</Field>
+        <Field label="Covers">
+          Seeds {String(p().name || "").replace("-", " through ")}
+        </Field>
+      </Show>
+
+      <Show when={tool() === "propose_create_position_pool"}>
+        <Field label="Pool">{p().name}</Field>
+        <Field label="Seeds">
+          <SeedList seeds={p().seeding} teamName={teamName} />
+        </Field>
+      </Show>
+
+      <Show when={tool() === "propose_create_field"}>
+        <Field label="Name">{p().name}</Field>
+        <Show when={p().address}>
+          <Field label="Address">{p().address}</Field>
+        </Show>
+        <Field label="Broadcast">{p().is_broadcasted ? "Yes" : "No"}</Field>
+      </Show>
+
+      <Show when={tool() === "propose_update_field"}>
+        <Field label="Field">
+          {p().current_name ||
+            props.fieldName?.(p().field_id) ||
+            `#${p().field_id}`}
+        </Field>
+        <Show when={p().name}>
+          <Field label="New name">{p().name}</Field>
+        </Show>
+        <Show when={"address" in p()}>
+          <Field label="Address">{p().address || "—"}</Field>
+        </Show>
+        <Show when={"is_broadcasted" in p()}>
+          <Field label="Broadcast">{p().is_broadcasted ? "Yes" : "No"}</Field>
+        </Show>
+      </Show>
+
+      <Show when={tool() === "propose_delete_field"}>
+        <Field label="Field">{p().name || `#${p().field_id}`}</Field>
+        <p class="text-xs text-red-700 dark:text-red-400">
+          Matches must already be moved off this field. Deleting it cannot be
+          undone from this tab.
+        </p>
+      </Show>
+
+      <Show when={tool() === "propose_create_cross_pool"}>
+        <p class="text-xs" style={{ color: "var(--agent-ink)" }}>
+          Creates the cross-pool stage. Matches are a separate proposal.
+        </p>
+      </Show>
+
+      <Show when={tool() === "propose_update_match"}>
+        <Field label="Match">#{p().match_id}</Field>
+        <Show when={p().time}>
+          <Field label="Time">{p().time}</Field>
+        </Show>
+        <Show when={p().field_id}>
+          <Field label="Field">
+            {props.fieldName?.(p().field_id) || p().field_id}
+          </Field>
+        </Show>
+        <Show when={p().duration_mins}>
+          <Field label="Duration">{p().duration_mins} min</Field>
+        </Show>
+        <Show when={p().seed_1 != null && p().seed_2 != null}>
+          <Field label="Seeds">
+            {p().seed_1} vs {p().seed_2}
+          </Field>
+        </Show>
+      </Show>
+
+      <Show when={tool() === "propose_update_match_seeds"}>
+        <div class="space-y-1">
+          <For each={p().updates || []}>
+            {row => (
+              <div
+                class="flex items-center gap-1.5 text-xs"
+                style={{ color: "var(--agent-ink)" }}
+              >
+                <span style={{ color: "var(--agent-ink-muted)" }}>
+                  #{row.match_id}
+                </span>
+                <span class="tabular-nums">
+                  {row.seed_1} vs {row.seed_2}
+                </span>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <Show when={tool() === "propose_generate_fixtures"}>
+        <p class="text-xs" style={{ color: "var(--agent-ink)" }}>
+          Pairs the next Swiss round and fills bracket placeholders. Does not
+          create new matches.
+        </p>
+      </Show>
+
+      <Show when={tool() === "propose_create_cross_pool_matches"}>
+        <Field label="Matches">{(p().seed_pairs || []).length}</Field>
+        <div class="space-y-1">
+          <For each={p().seed_pairs || []}>
+            {pair => (
+              <div
+                class="flex items-center gap-1.5 text-xs"
+                style={{ color: "var(--agent-ink)" }}
+              >
+                <span class="tabular-nums">Seed {pair[0]}</span>
+                <span style={{ color: "var(--agent-ink-muted)" }}>vs</span>
+                <span class="tabular-nums">Seed {pair[1]}</span>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <Show when={tool() === "propose_update_seeding"}>
+        <Field label="Teams">{Object.keys(p().seeding || {}).length}</Field>
+        <p class="text-xs text-amber-700 dark:text-amber-500">
+          Reseeds every pool and Swiss group. Only possible before the
+          tournament starts.
+        </p>
+      </Show>
+
+      <Show when={tool() === "propose_match_score"}>
+        <Field label="Match">{p().match_id}</Field>
+        <Field label="Score">
+          {p().score_team_1} - {p().score_team_2}
+          {p().forfeit ? " (forfeit)" : ""}
+        </Field>
+        <p class="mt-1 text-[11px]" style={{ color: "var(--agent-ink-muted)" }}>
+          Completes the match, recomputes standings and seeding, and fills the
+          next stage. Results cannot be edited afterwards.
+        </p>
+      </Show>
+
+      <Show when={tool() === "propose_spirit_scores"}>
+        <Field label="Match">{p().match_id}</Field>
+        <For
+          each={[
+            ["team_1_received", "Team 1 received"],
+            ["team_2_received", "Team 2 received"],
+            ["team_1_self", "Team 1 self"],
+            ["team_2_self", "Team 2 self"]
+          ].filter(([key]) => p()[key])}
+        >
+          {([key, label]) => (
+            <Field label={label}>
+              {p()[key].rules}/{p()[key].fouls}/{p()[key].fair}/
+              {p()[key].positive}/{p()[key].communication}
+              <Show when={p()[key].mvp_id}>
+                {" · MVP "}
+                <PlayerName id={p()[key].mvp_id} names={playerNames()} />
+              </Show>
+              <Show when={p()[key].msp_id}>
+                {" · MSP "}
+                <PlayerName id={p()[key].msp_id} names={playerNames()} />
+              </Show>
+            </Field>
+          )}
+        </For>
+      </Show>
+
+      <Show when={tool() === "propose_delete_stage"}>
+        <Field label="Stage">
+          {p().name
+            ? `${p().stage} ${p().name}`
+            : `${p().stage} #${p().stage_id}`}
+        </Field>
+        <p class="mt-1 text-[11px]" style={{ color: "var(--agent-ink-muted)" }}>
+          Deletes the stage and every match in it.
+        </p>
+      </Show>
+
+      <Show
+        when={
+          tool() === "propose_bulk_schedule" ||
+          tool() === "propose_recommended_schedule" ||
+          tool() === "propose_shift_schedule"
+        }
+      >
+        <Field label="Matches">{(p().assignments || []).length}</Field>
+        <div
+          class="max-h-40 overflow-y-auto rounded border"
+          style={{ "border-color": "var(--agent-line)" }}
+        >
+          <table class="w-full text-left text-[11px]">
+            <thead
+              class="sticky top-0"
+              style={{
+                "background-color": "var(--agent-canvas)",
+                color: "var(--agent-ink-muted)"
+              }}
+            >
+              <tr>
+                <th class="px-2 py-1 font-medium">Match</th>
+                <th class="px-2 py-1 font-medium">Field</th>
+                <th class="px-2 py-1 font-medium">Time</th>
+              </tr>
+            </thead>
+            <tbody style={{ color: "var(--agent-ink)" }}>
+              <For each={p().assignments || []}>
+                {a => (
+                  <tr
+                    class="border-t"
+                    style={{ "border-color": "var(--agent-line)" }}
+                  >
+                    <td class="px-2 py-1 tabular-nums">
+                      {a.match_name || `#${a.match_id}`}
+                    </td>
+                    <td class="px-2 py-1">
+                      {props.fieldName?.(a.field_id) || a.field_id}
+                    </td>
+                    <td class="px-2 py-1 tabular-nums">
+                      {String(a.time || "")
+                        .replace("T", " ")
+                        .slice(0, 16)}
+                    </td>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+          </table>
+        </div>
+      </Show>
+
+      <Show when={tool() === "propose_delete_match"}>
+        <Field label="Match">#{p().match_id}</Field>
+        <p class="text-xs text-red-700 dark:text-red-400">
+          Deleting a match cannot be undone from this tab.
+        </p>
+      </Show>
+
+      <Show when={tool() === "propose_full_setup"}>
+        <Show when={p().pool_defs?.length}>
+          <For each={p().pool_defs}>
+            {def_ => (
+              <div
+                class="rounded border p-2"
+                style={{ "border-color": "var(--agent-line)" }}
+              >
+                <Field label="Pool">{def_.name}</Field>
+                <Field label="Seeds">
+                  <SeedList seeds={def_.seeding} teamName={teamName} />
+                </Field>
+              </div>
+            )}
+          </For>
+        </Show>
+        <Show when={p().swiss_defs?.length}>
+          <For each={p().swiss_defs}>
+            {def_ => (
+              <div
+                class="rounded border p-2"
+                style={{ "border-color": "var(--agent-line)" }}
+              >
+                <Field label="Swiss">{def_.name}</Field>
+                <Field label="Rounds">{def_.num_rounds}</Field>
+                <Field label="Seeds">
+                  <SeedList seeds={def_.seeding} teamName={teamName} />
+                </Field>
+              </div>
+            )}
+          </For>
+        </Show>
+        <Show when={p().bracket_names?.length}>
+          <Field label="Brackets">{p().bracket_names.join(", ")}</Field>
+        </Show>
+        <Show when={p().format}>
+          <Field label="Format">{p().format}</Field>
+        </Show>
+      </Show>
+
+      <Show when={tool() === "propose_start_tournament"}>
+        <p class="text-xs" style={{ color: "var(--agent-ink)" }}>
+          Assigns teams into pools and Swiss groups from the current seeding and
+          moves the tournament to Live.
+        </p>
+        <p class="text-xs text-amber-700 dark:text-amber-500">
+          Seeding can no longer be changed afterwards.
+        </p>
+      </Show>
+    </div>
+  );
+};
+
+const ProposalCard = props => {
+  const [showJson, setShowJson] = createSignal(false);
+  const p = () => props.proposal;
+  const locked = () => props.disabled || props.confirming || props.rejecting;
+  const title = () => {
+    if (p().tool_name === "propose_full_setup") {
+      const payload = p().payload || {};
+      const parts = [];
+      if (payload.pool_defs?.length)
+        parts.push(
+          `${payload.pool_defs.length} pool${
+            payload.pool_defs.length > 1 ? "s" : ""
+          }`
+        );
+      if (payload.swiss_defs?.length)
+        parts.push(
+          `${payload.swiss_defs.length} Swiss group${
+            payload.swiss_defs.length > 1 ? "s" : ""
+          }`
+        );
+      if (payload.bracket_names?.length)
+        parts.push(
+          `${payload.bracket_names.length} bracket${
+            payload.bracket_names.length > 1 ? "s" : ""
+          }`
+        );
+      return parts.length
+        ? `Create ${parts.join(" + ")}`
+        : "Full tournament setup";
+    }
+    return TOOL_TITLES[p().tool_name] || p().tool_name;
+  };
+  const highImpact = () => HIGH_IMPACT.has(p().tool_name);
+
+  return (
+    <div
+      class="rounded-lg border transition-shadow duration-200"
+      style={{
+        "border-color": highImpact()
+          ? "rgb(217 119 6 / 0.5)"
+          : "var(--agent-line-strong)",
+        "background-color": "var(--agent-raised)"
+      }}
+    >
+      <div class="p-3">
+        <div class="mb-2 flex items-center gap-2">
+          <span
+            class="text-sm font-semibold"
+            style={{ color: "var(--agent-ink)" }}
+          >
+            {title()}
+          </span>
+          <Show when={highImpact()}>
+            <span class="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-800 dark:bg-amber-900/60 dark:text-amber-300">
+              High impact
+            </span>
+          </Show>
+        </div>
+        <Show when={p().summary}>
+          <p class="mb-2 text-xs" style={{ color: "var(--agent-ink-muted)" }}>
+            {p().summary}
+          </p>
+        </Show>
+
+        <ProposalPreview
+          proposal={p()}
+          seedToTeamName={props.seedToTeamName}
+          fieldName={props.fieldName}
+        />
+
+        <Show when={props.error}>
+          <div
+            class="mt-3 rounded-md border border-red-300 bg-red-50 px-2.5 py-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300"
+            role="alert"
+          >
+            <p>{props.error}</p>
+            <Show when={props.onAskFix}>
+              <button
+                type="button"
+                class="mt-2 inline-flex cursor-pointer items-center rounded-md bg-red-800 px-2.5 py-1 text-[11px] font-medium text-white transition-colors duration-150 hover:bg-red-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-red-700 dark:hover:bg-red-600"
+                disabled={props.disabled}
+                onClick={() => props.onAskFix?.()}
+              >
+                Ask the agent to fix this
+              </button>
+            </Show>
+          </div>
+        </Show>
+
+        <div class="mt-3 flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            class="inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-emerald-700 px-3 py-1.5 text-xs font-medium text-white transition-colors duration-150 hover:bg-emerald-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-emerald-600 dark:hover:bg-emerald-700"
+            disabled={locked()}
+            onClick={() => props.onConfirm?.()}
+          >
+            <Show when={props.confirming}>
+              <Spinner noMargin height="12" width="12" />
+            </Show>
+            Confirm
+          </button>
+          <button
+            type="button"
+            class="cursor-pointer rounded-md border px-3 py-1.5 text-xs font-medium transition-colors duration-150 hover:bg-black/[0.04] focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-white/[0.06]"
+            style={{
+              "border-color": "var(--agent-line-strong)",
+              color: "var(--agent-ink-muted)"
+            }}
+            disabled={locked()}
+            onClick={() => props.onReject?.()}
+          >
+            Reject
+          </button>
+          <button
+            type="button"
+            class="ml-auto cursor-pointer text-[11px] underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            style={{ color: "var(--agent-ink-muted)" }}
+            onClick={() => setShowJson(!showJson())}
+            aria-expanded={showJson()}
+          >
+            {showJson() ? "Hide payload" : "View payload"}
+          </button>
+        </div>
+      </div>
+
+      <Show when={showJson()}>
+        <pre
+          class="max-h-40 overflow-auto border-t px-3 py-2 font-mono text-[11px] leading-snug"
+          style={{
+            "border-color": "var(--agent-line)",
+            color: "var(--agent-ink-muted)"
+          }}
+        >
+          {JSON.stringify(p().payload, null, 2)}
+        </pre>
+      </Show>
+    </div>
+  );
+};
+
+export default ProposalCard;

--- a/frontend/src/components/tournament-manager/agent/QuestionCard.js
+++ b/frontend/src/components/tournament-manager/agent/QuestionCard.js
@@ -1,0 +1,164 @@
+import { createSignal, For, Show } from "solid-js";
+
+/**
+ * The agent's clarifying question, rendered on the AI surface. Single/multi
+ * select options as a quiet bordered list, a free-text "other" on every
+ * question, and Submit / Skip actions.
+ */
+const QuestionCard = props => {
+  const q = () => props.question;
+  const [selected, setSelected] = createSignal([]);
+  const [other, setOther] = createSignal("");
+
+  const toggle = id => {
+    if (q().selection_mode === "single") {
+      setSelected([id]);
+      return;
+    }
+    const cur = selected();
+    if (cur.includes(id)) {
+      setSelected(cur.filter(x => x !== id));
+    } else {
+      setSelected([...cur, id]);
+    }
+  };
+
+  const canSubmit = () => selected().length > 0 || !!other().trim();
+
+  return (
+    <div
+      class="mt-3 rounded-lg border p-4"
+      style={{
+        "border-color": "rgb(217 119 6 / 0.4)",
+        "background-color": "var(--agent-raised)"
+      }}
+      role="group"
+      aria-label="Clarifying question"
+    >
+      <div class="mb-2 flex items-center gap-2">
+        <svg
+          class="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-500"
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z" />
+        </svg>
+        <span class="text-[11px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-500">
+          Clarifying question
+        </span>
+      </div>
+      <p
+        class="mb-1 text-sm font-semibold"
+        style={{ color: "var(--agent-ink)" }}
+      >
+        {q().prompt}
+      </p>
+      <Show when={q().context}>
+        <p class="mb-3 text-xs" style={{ color: "var(--agent-ink-muted)" }}>
+          {q().context}
+        </p>
+      </Show>
+
+      <div class="mb-3 mt-2 space-y-1.5">
+        <For each={q().options || []}>
+          {opt => (
+            <label
+              for={`agent-q-${q().id}-${opt.id}`}
+              class="flex cursor-pointer items-start gap-3 rounded-lg border px-3 py-2.5 transition-colors duration-150 hover:bg-black/[0.03] dark:hover:bg-white/[0.05]"
+              style={{
+                "border-color": selected().includes(opt.id)
+                  ? "var(--agent-accent)"
+                  : "var(--agent-line)"
+              }}
+            >
+              <input
+                id={`agent-q-${q().id}-${opt.id}`}
+                type={q().selection_mode === "single" ? "radio" : "checkbox"}
+                name={`agent-q-${q().id}`}
+                value={opt.id}
+                checked={selected().includes(opt.id)}
+                onChange={() => toggle(opt.id)}
+                disabled={props.disabled}
+                class="mt-0.5 h-4 w-4 shrink-0"
+                style={{ "accent-color": "var(--agent-accent)" }}
+              />
+              <span class="min-w-0">
+                <span
+                  class="block text-sm font-medium"
+                  style={{ color: "var(--agent-ink)" }}
+                >
+                  {opt.label}
+                </span>
+                <Show when={opt.description}>
+                  <span
+                    class="mt-0.5 block text-xs"
+                    style={{ color: "var(--agent-ink-muted)" }}
+                  >
+                    {opt.description}
+                  </span>
+                </Show>
+              </span>
+            </label>
+          )}
+        </For>
+      </div>
+
+      <div class="mb-3">
+        <label
+          for={`agent-q-other-${q().id}`}
+          class="mb-1.5 block text-xs font-medium"
+          style={{ color: "var(--agent-ink-muted)" }}
+        >
+          Or type your own answer
+        </label>
+        <input
+          id={`agent-q-other-${q().id}`}
+          type="text"
+          class="block w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 disabled:opacity-50"
+          style={{
+            "border-color": "var(--agent-line-strong)",
+            "background-color": "var(--agent-canvas)",
+            color: "var(--agent-ink)"
+          }}
+          placeholder="Type another option…"
+          value={other()}
+          onInput={e => setOther(e.target.value)}
+          disabled={props.disabled}
+        />
+      </div>
+
+      <div class="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="cursor-pointer rounded-md bg-amber-700 px-4 py-1.5 text-xs font-medium text-white transition-colors duration-150 hover:bg-amber-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-amber-600 dark:hover:bg-amber-700"
+          disabled={props.disabled || !canSubmit()}
+          onClick={() =>
+            props.onSubmit?.({
+              selected_ids: selected(),
+              other_text: other().trim() || null,
+              skip: false
+            })
+          }
+        >
+          Submit
+        </button>
+        <button
+          type="button"
+          class="cursor-pointer rounded-md border px-4 py-1.5 text-xs font-medium transition-colors duration-150 hover:bg-black/[0.04] focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-white/[0.06]"
+          style={{
+            "border-color": "var(--agent-line-strong)",
+            color: "var(--agent-ink-muted)"
+          }}
+          disabled={props.disabled}
+          onClick={() => props.onSubmit?.({ selected_ids: [], skip: true })}
+        >
+          Skip
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default QuestionCard;

--- a/frontend/src/components/tournament-manager/agent/QuestionSnapshot.js
+++ b/frontend/src/components/tournament-manager/agent/QuestionSnapshot.js
@@ -1,0 +1,80 @@
+import { For, Show } from "solid-js";
+
+/**
+ * Read-only recap of a question after it was answered or skipped.
+ *
+ * Default export only: solid-hot-loader wraps every .js under components/ and
+ * drops named exports (same reason QuestionCard is imported as default).
+ */
+const QuestionSnapshot = props => {
+  const q = () => props.question || {};
+  const answer = () => q().answer || {};
+  const selected = () => new Set((answer().selected_ids || []).map(String));
+  const skipped = () => !!(answer().skipped || answer().cancelled);
+
+  return (
+    <div
+      class="mt-3 rounded-lg border p-4"
+      style={{
+        "border-color": "var(--agent-line)",
+        "background-color": "var(--agent-raised)"
+      }}
+    >
+      <div class="mb-2 flex items-center gap-2">
+        <span
+          class="text-[11px] font-medium uppercase tracking-wide"
+          style={{ color: "var(--agent-ink-muted)" }}
+        >
+          Question
+        </span>
+        <Show when={skipped()}>
+          <span class="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+            Skipped
+          </span>
+        </Show>
+      </div>
+      <p
+        class="mb-1 text-sm font-semibold"
+        style={{ color: "var(--agent-ink)" }}
+      >
+        {q().prompt}
+      </p>
+      <Show when={q().context}>
+        <p class="mb-2 text-xs" style={{ color: "var(--agent-ink-muted)" }}>
+          {q().context}
+        </p>
+      </Show>
+      <ul class="mt-2 space-y-1">
+        <For each={q().options || []}>
+          {opt => (
+            <li
+              class="flex items-start gap-2 text-sm"
+              style={{
+                color: selected().has(String(opt.id))
+                  ? "var(--agent-ink)"
+                  : "var(--agent-ink-muted)"
+              }}
+            >
+              <span class="mt-0.5 w-3 shrink-0 text-center text-[11px]">
+                {selected().has(String(opt.id)) ? "✓" : "•"}
+              </span>
+              <span>
+                {opt.label}
+                <Show when={opt.description}>
+                  <span class="ml-1 opacity-70">— {opt.description}</span>
+                </Show>
+              </span>
+            </li>
+          )}
+        </For>
+      </ul>
+      <Show when={answer().other_text}>
+        <p class="mt-2 text-sm" style={{ color: "var(--agent-ink)" }}>
+          Own answer: {answer().other_text}
+        </p>
+      </Show>
+    </div>
+  );
+};
+
+export default QuestionSnapshot;

--- a/frontend/src/components/tournament-manager/agent/ToolEventTimeline.js
+++ b/frontend/src/components/tournament-manager/agent/ToolEventTimeline.js
@@ -1,0 +1,255 @@
+import { createSignal, For, Show } from "solid-js";
+
+/** Tool names are API-shaped; show staff what the call actually does. */
+const TOOL_LABELS = {
+  get_tournament_overview: "Read tournament overview",
+  list_teams_seeding: "Read teams & seeding",
+  list_pools: "Read pools",
+  list_swiss_rounds: "Read Swiss rounds",
+  list_brackets: "Read brackets",
+  list_cross_pools: "Read cross pool",
+  list_position_pools: "Read position pools",
+  list_fields: "Read fields",
+  list_matches: "Read matches",
+  get_standings: "Read standings",
+  get_swiss_standings: "Read Swiss standings",
+  list_stages: "Read stage progress",
+  list_proposals: "Read pending proposals",
+  check_schedule_conflicts: "Check schedule conflicts",
+  ask_user: "Ask a question",
+  propose_pool_stage: "Propose pool stage",
+  propose_create_pool: "Propose pool",
+  propose_create_swiss_round: "Propose Swiss round",
+  propose_create_cross_pool: "Propose cross pool",
+  propose_create_cross_pool_matches: "Propose cross pool matches",
+  propose_create_bracket: "Propose bracket",
+  propose_create_position_pool: "Propose position pool",
+  propose_create_field: "Propose field",
+  propose_update_field: "Propose field update",
+  propose_delete_field: "Propose field deletion",
+  propose_update_seeding: "Propose seeding change",
+  propose_update_match: "Propose match change",
+  propose_update_match_seeds: "Propose match seed change",
+  propose_delete_match: "Propose match deletion",
+  propose_bulk_schedule: "Propose schedule",
+  propose_recommended_schedule: "Propose schedule",
+  propose_match_score: "Propose match result",
+  propose_spirit_scores: "Propose spirit scores",
+  propose_shift_schedule: "Propose schedule shift",
+  propose_delete_stage: "Propose stage deletion",
+  propose_full_setup: "Propose full setup",
+  propose_start_tournament: "Propose tournament start",
+  propose_generate_fixtures: "Propose fixture population"
+};
+
+const STATUS_DOT = {
+  running: "bg-blue-500",
+  ok: "bg-emerald-500",
+  proposal: "bg-blue-500",
+  question: "bg-amber-500",
+  error: "bg-red-500"
+};
+
+const labelFor = name => TOOL_LABELS[name] || name;
+
+const formatDuration = ms => {
+  if (ms == null) return "";
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
+};
+
+const prettyArgs = args => {
+  if (!args || Object.keys(args).length === 0) return null;
+  try {
+    return JSON.stringify(args, null, 2);
+  } catch (e) {
+    return null;
+  }
+};
+
+const Chevron = props => (
+  <svg
+    class={`h-3 w-3 shrink-0 transition-transform duration-200 ${
+      props.open ? "rotate-180" : ""
+    }`}
+    style={{ color: "var(--agent-ink-muted)" }}
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 10 6"
+  >
+    <path
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      d="m1 1 4 4 4-4"
+    />
+  </svg>
+);
+
+const ToolEventRow = props => {
+  const [expanded, setExpanded] = createSignal(false);
+  const event = () => props.event;
+  const status = () => event().status || "ok";
+  const running = () => status() === "running";
+  const args = () => prettyArgs(event().arguments);
+
+  return (
+    <li>
+      <button
+        type="button"
+        class="flex w-full cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-left transition-colors duration-150 hover:bg-black/[0.04] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-white/[0.06]"
+        onClick={() => setExpanded(!expanded())}
+        aria-expanded={expanded()}
+      >
+        <Show
+          when={!running()}
+          fallback={
+            <span
+              class="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-blue-500"
+              aria-hidden="true"
+            />
+          }
+        >
+          <span
+            class={`h-1.5 w-1.5 shrink-0 rounded-full ${
+              STATUS_DOT[status()] || STATUS_DOT.ok
+            }`}
+            aria-hidden="true"
+          />
+        </Show>
+        <span
+          class="shrink-0 text-xs font-medium"
+          style={{ color: "var(--agent-ink)" }}
+        >
+          {labelFor(event().name)}
+        </span>
+        <span
+          class="min-w-0 flex-1 truncate text-xs"
+          style={{
+            color: status() === "error" ? undefined : "var(--agent-ink-muted)"
+          }}
+          classList={{ "text-red-600 dark:text-red-400": status() === "error" }}
+        >
+          {running() ? "Running…" : event().summary}
+        </span>
+        <Show when={event().duration_ms != null}>
+          <span
+            class="shrink-0 text-[10px] tabular-nums"
+            style={{ color: "var(--agent-ink-muted)" }}
+          >
+            {formatDuration(event().duration_ms)}
+          </span>
+        </Show>
+        <Chevron open={expanded()} />
+      </button>
+      <Show when={expanded()}>
+        <div
+          class="ml-3.5 mt-1 space-y-1 border-l pl-3"
+          style={{ "border-color": "var(--agent-line-strong)" }}
+        >
+          <p
+            class="font-mono text-[10px]"
+            style={{ color: "var(--agent-ink-muted)" }}
+          >
+            {event().name}
+          </p>
+          <Show
+            when={args()}
+            fallback={
+              <p
+                class="text-xs italic"
+                style={{ color: "var(--agent-ink-muted)" }}
+              >
+                No arguments
+              </p>
+            }
+          >
+            <pre class="max-h-48 overflow-auto rounded bg-gray-900 p-2 font-mono text-[11px] leading-snug text-gray-100">
+              {args()}
+            </pre>
+          </Show>
+        </div>
+      </Show>
+    </li>
+  );
+};
+
+/**
+ * Tool activity for one assistant turn. Collapsed to a single line by default;
+ * expands to per-call rows, and each row expands to the exact arguments sent.
+ */
+const ToolEventTimeline = props => {
+  const [open, setOpen] = createSignal(props.defaultOpen ?? false);
+  const events = () => props.events || [];
+  const errorCount = () => events().filter(e => e.status === "error").length;
+  const runningCount = () =>
+    events().filter(e => e.status === "running").length;
+
+  const headline = () => {
+    const n = events().length;
+    if (runningCount() > 0) {
+      const current = events().find(e => e.status === "running");
+      return current ? labelFor(current.name) + "…" : "Working…";
+    }
+    return `Used ${n} tool${n === 1 ? "" : "s"}`;
+  };
+
+  return (
+    <Show when={events().length > 0}>
+      <div
+        class="mb-2 rounded-lg border px-2 py-1.5"
+        style={{
+          "border-color": "var(--agent-line)",
+          "background-color": "var(--agent-canvas)"
+        }}
+      >
+        <button
+          type="button"
+          class="flex w-full cursor-pointer items-center gap-2 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          onClick={() => setOpen(!open())}
+          aria-expanded={open()}
+        >
+          <svg
+            class="h-3.5 w-3.5 shrink-0"
+            style={{ color: "var(--agent-ink-muted)" }}
+            classList={{ "animate-spin": runningCount() > 0 }}
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z"
+            />
+          </svg>
+          <span
+            class="text-xs font-medium"
+            style={{ color: "var(--agent-ink-muted)" }}
+          >
+            {headline()}
+            <Show when={errorCount() > 0}>
+              <span class="ml-1 text-red-600 dark:text-red-400">
+                ({errorCount()} error{errorCount() === 1 ? "" : "s"})
+              </span>
+            </Show>
+          </span>
+          <span class="ml-auto">
+            <Chevron open={open()} />
+          </span>
+        </button>
+        <Show when={open()}>
+          <ul class="mt-1 space-y-0.5">
+            <For each={events()}>{event => <ToolEventRow event={event} />}</For>
+          </ul>
+        </Show>
+      </div>
+    </Show>
+  );
+};
+
+export default ToolEventTimeline;

--- a/frontend/src/components/tournament-manager/agent/TournamentAgentTab.js
+++ b/frontend/src/components/tournament-manager/agent/TournamentAgentTab.js
@@ -1,0 +1,1243 @@
+import {
+  createMutation,
+  createQuery,
+  useQueryClient
+} from "@tanstack/solid-query";
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  onCleanup,
+  Show
+} from "solid-js";
+
+import {
+  clearTournamentAgentHistory,
+  confirmTournamentAgentProposal,
+  fetchBrackets,
+  fetchCrossPool,
+  fetchFieldsByTournamentId,
+  fetchMatches,
+  fetchPools,
+  fetchSwissRounds,
+  fetchTeams,
+  fetchTournamentAgentHistory,
+  fetchTournamentAgentModels,
+  fetchTournaments,
+  rejectTournamentAgentProposal,
+  setTournamentAgentModel,
+  streamTournamentAgentAnswer,
+  streamTournamentAgentMessage
+} from "../../../queries";
+import { useStore } from "../../../store";
+import { filterManageableTournaments } from "../../../utils";
+import StyledMarkdown from "../../StyledMarkdown";
+import ModelPicker from "./ModelPicker";
+import ProposalCard from "./ProposalCard";
+import QuestionCard from "./QuestionCard";
+import QuestionSnapshot from "./QuestionSnapshot";
+import ToolEventTimeline from "./ToolEventTimeline";
+import TournamentRail from "./TournamentRail";
+
+/**
+ * Chat-scale markdown classes for agent replies, all Tailwind. StyledMarkdown's
+ * default map styles h1/h2 as large centered blue page titles (right for
+ * rules/help pages, wrong inside a conversation); this map keeps a tight
+ * inline-scale rhythm. Keys are CSS selectors applied via querySelectorAll, so
+ * order matters: compound keys ("li > p", "pre code") run after their base tag
+ * and override it — that "li > p" reset is what keeps loose (blank-line-
+ * separated) bullet lists from gaining a full paragraph gap between items.
+ *
+ * Kept inline rather than in a sibling module: solid-hot-loader wraps every .js
+ * under components/ as a component and drops named exports, so a constants-only
+ * module can't be imported by name here.
+ */
+const agentClassMap = {
+  a: "font-medium text-blue-700 underline underline-offset-2 hover:no-underline dark:text-blue-300",
+  p: "mb-1.5 last:mb-0",
+  h1: "text-base font-semibold mt-2.5 mb-1 first:mt-0",
+  h2: "text-[0.9375rem] font-semibold mt-2.5 mb-1 first:mt-0",
+  h3: "text-sm font-semibold mt-2 mb-0.5 first:mt-0",
+  ol: "mb-1.5 ml-5 list-decimal space-y-0.5 last:mb-0",
+  ul: "mb-1.5 ml-5 list-disc space-y-0.5 last:mb-0",
+  li: "leading-snug",
+  blockquote:
+    "mb-1.5 border-l-2 pl-3 italic opacity-80 border-[color:var(--agent-line-strong)] last:mb-0",
+  hr: "my-3 border-t border-[color:var(--agent-line)]",
+  table:
+    "mb-1.5 w-full table-auto border-collapse text-left text-[0.8125rem] last:mb-0",
+  thead: "border-b border-[color:var(--agent-line-strong)]",
+  th: "px-2 py-1 font-semibold",
+  "tbody tr": "border-b border-[color:var(--agent-line)] last:border-0",
+  "tbody td": "px-2 py-1 align-top",
+  pre: "mb-1.5 overflow-x-auto rounded-lg bg-[color:var(--agent-user-chip)] p-3 text-[0.8125rem] leading-normal last:mb-0",
+  code: "rounded bg-[color:var(--agent-user-chip)] px-1 py-0.5 text-[0.8125em]",
+  "pre code": "bg-transparent p-0 text-[0.8125rem]",
+  "li > p": "mb-0"
+};
+
+const EVENT_KIND = { MXD: "mixed", OPN: "open", WMN: "women's" };
+
+const asList = data => (Array.isArray(data) ? data : []);
+
+const ymd = value => (value ? String(value).slice(0, 10) : "");
+
+const plural = (count, one, many = `${one}s`) =>
+  `${count} ${count === 1 ? one : many}`;
+
+const SCHEDULE_PLAN_TOOLS = new Set([
+  "propose_recommended_schedule",
+  "propose_bulk_schedule",
+  "propose_shift_schedule"
+]);
+
+const assignmentMatchIds = payload =>
+  new Set(
+    (payload?.assignments || [])
+      .map(row => row?.match_id)
+      .filter(id => id != null)
+  );
+
+const keepLiveProposals = (prev, incoming) => {
+  if (!SCHEDULE_PLAN_TOOLS.has(incoming.tool_name)) {
+    return [...prev, incoming];
+  }
+  const newIds = assignmentMatchIds(incoming.payload);
+  if (!newIds.size) return [...prev, incoming];
+  return [
+    ...prev.filter(proposal => {
+      if (!SCHEDULE_PLAN_TOOLS.has(proposal.tool_name)) return true;
+      const ids = assignmentMatchIds(proposal.payload);
+      for (const id of ids) {
+        if (newIds.has(id)) return false;
+      }
+      return true;
+    }),
+    incoming
+  ];
+};
+
+const confirmFixPrompt = (proposal, error) =>
+  [
+    `Staff could not Confirm proposal #${proposal.id} (${proposal.tool_name}: ${
+      proposal.summary || "untitled"
+    }).`,
+    `Apply error: ${error}`,
+    "Call list_proposals, read current tournament state, then call the matching propose_* tool with a corrected payload.",
+    "Re-proposing retires this card. Do not reuse the failed payload. Do not ask staff to reject it first."
+  ].join(" ");
+
+/**
+ * Starter chips for an empty chat. Built from this tournament so we never
+ * offer "16 mixed teams on 3 fields" when the event is 8 teams on 2.
+ */
+const buildStarterPrompts = s => {
+  const kind = EVENT_KIND[s.eventType];
+  const teamPhrase =
+    s.teamCount > 0
+      ? `the ${s.teamCount} registered${kind ? ` ${kind}` : ""} ${
+          s.teamCount === 1 ? "team" : "teams"
+        }`
+      : "the registered teams";
+  const fieldPhrase =
+    s.fieldCount > 0 ? ` on ${plural(s.fieldCount, "field")}` : "";
+  const datePhrase =
+    s.startDate && s.endDate && s.startDate !== s.endDate
+      ? ` from ${s.startDate} to ${s.endDate}`
+      : s.startDate
+      ? ` on ${s.startDate}`
+      : "";
+
+  if (s.status === "COM") {
+    return [
+      {
+        title: "Summarise the event",
+        prompt: "Summarise how this tournament was set up and how it finished"
+      }
+    ];
+  }
+
+  if (s.teamCount === 0) {
+    return [
+      {
+        title: "What's in place?",
+        prompt:
+          "Summarise this tournament: teams, stages, fields, and what's still missing"
+      }
+    ];
+  }
+
+  const items = [];
+  const live = s.status === "LIV";
+  const hasFormat = s.poolCount > 0 || s.swissCount > 0;
+
+  if (!live && !hasFormat) {
+    if (s.fieldCount === 0) {
+      items.push({
+        title: "Add fields first",
+        prompt: `This event has ${teamPhrase}${datePhrase} but no fields yet. Ask me how many fields to add (2, 3, or 4), then propose them.`
+      });
+    }
+    items.push({
+      title: `Set up ${plural(s.teamCount, "team")}`,
+      prompt:
+        s.fieldCount === 0
+          ? `Set up this tournament for ${teamPhrase}${datePhrase}. Start with fields, then the format — don't schedule yet.`
+          : `Set up this tournament for ${teamPhrase}${fieldPhrase}${datePhrase}. Recommend a format.`
+    });
+    items.push({
+      title: "Recommend a format",
+      prompt: `Recommend snake-seeded pools (or Swiss) for ${teamPhrase}`
+    });
+    return items;
+  }
+
+  if (!live && s.fieldCount === 0) {
+    items.push({
+      title: "Add a field",
+      prompt: "Add a playing field so matches can be scheduled"
+    });
+  }
+
+  if (s.unscheduledCount > 0 && s.fieldCount > 0) {
+    items.push({
+      title: `Schedule ${plural(s.unscheduledCount, "match", "matches")}`,
+      prompt: `Recommend a schedule for the ${plural(
+        s.unscheduledCount,
+        "match",
+        "matches"
+      )} that don't have a time or field yet. Use 75 minute games${datePhrase}.`
+    });
+  }
+
+  if (!live && s.poolCount > 0 && !s.hasCrossPool) {
+    items.push({
+      title: "Add cross pool",
+      prompt: "Set up the cross pool stage and its matches after pools"
+    });
+  }
+
+  if (!live && hasFormat && s.bracketCount === 0 && s.teamCount >= 4) {
+    items.push({
+      title: "Add brackets",
+      prompt:
+        "Set up 1-4 / 5-8 brackets with 3rd-place push-in games, not just semis and a final"
+    });
+  }
+
+  if (s.status === "SCH" && s.matchCount > 0 && s.unscheduledCount === 0) {
+    items.push({
+      title: "Start the tournament",
+      prompt: "Start the tournament and assign teams from seeding"
+    });
+  }
+
+  if (live) {
+    items.push({
+      title: "Who still needs a score?",
+      prompt: "Which matches still need a score?"
+    });
+    items.push({
+      title: "Show standings",
+      prompt: "Show the current standings"
+    });
+    if (s.unscheduledCount > 0) {
+      items.push({
+        title: "Unscheduled matches",
+        prompt: "Show the matches that still have no time or field"
+      });
+    }
+  }
+
+  return items.slice(0, 4);
+};
+
+/** A flying disc seen in slight perspective — the sport's mark, not a star. */
+const AgentMark = props => (
+  <svg
+    class={props.class}
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <ellipse
+      cx="12"
+      cy="12"
+      rx="9.5"
+      ry="5.5"
+      fill="currentColor"
+      opacity="0.16"
+    />
+    <ellipse
+      cx="12"
+      cy="12"
+      rx="9.5"
+      ry="5.5"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.6"
+    />
+    <ellipse
+      cx="12"
+      cy="12"
+      rx="5"
+      ry="2.7"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.3"
+      opacity="0.85"
+    />
+  </svg>
+);
+
+const EmptyState = props => {
+  const tid = () => props.tournamentId;
+  const enabled = () => !!tid();
+  const query = (key, fn) =>
+    createQuery(
+      () => [key, tid()],
+      () => fn(tid()),
+      {
+        get enabled() {
+          return enabled();
+        }
+      }
+    );
+
+  const poolsQuery = query("pools", fetchPools);
+  const swissQuery = query("swiss-rounds", fetchSwissRounds);
+  const bracketsQuery = query("brackets", fetchBrackets);
+  const crossPoolQuery = query("cross-pool", fetchCrossPool);
+  const fieldsQuery = query("fields", fetchFieldsByTournamentId);
+  const matchesQuery = query("matches", fetchMatches);
+
+  const prompts = createMemo(() => {
+    const tournament = props.tournament;
+    const teams = tournament?.teams;
+    const teamCount =
+      Array.isArray(teams) && teams.length
+        ? teams.length
+        : Object.keys(tournament?.current_seeding || {}).length;
+    const matches = asList(matchesQuery.data);
+    return buildStarterPrompts({
+      teamCount,
+      fieldCount: asList(fieldsQuery.data).length,
+      poolCount: asList(poolsQuery.data).length,
+      swissCount: asList(swissQuery.data).length,
+      bracketCount: asList(bracketsQuery.data).length,
+      hasCrossPool: !!crossPoolQuery.data?.id,
+      matchCount: matches.length,
+      unscheduledCount: matches.filter(m => !m.time || !m.field).length,
+      status: tournament?.status,
+      eventType: tournament?.event?.type,
+      startDate: ymd(tournament?.event?.start_date),
+      endDate: ymd(tournament?.event?.end_date)
+    });
+  });
+
+  const teamCount = () => {
+    const teams = props.tournament?.teams;
+    if (Array.isArray(teams) && teams.length) return teams.length;
+    return Object.keys(props.tournament?.current_seeding || {}).length;
+  };
+
+  const hasFormat = () =>
+    asList(poolsQuery.data).length > 0 || asList(swissQuery.data).length > 0;
+
+  return (
+    <div class="flex h-full flex-col items-center justify-center px-6 py-10">
+      <AgentMark
+        class="mb-4 h-8 w-8"
+        style={{ color: "var(--agent-accent)" }}
+      />
+      <h2
+        class="mb-1 font-serif text-2xl"
+        style={{ color: "var(--agent-ink)" }}
+      >
+        {hasFormat() ? "What should we do next?" : "What are we setting up?"}
+      </h2>
+      <p
+        class="mb-6 max-w-sm text-center text-sm"
+        style={{ color: "var(--agent-ink-muted)" }}
+      >
+        {teamCount() > 0
+          ? `${plural(
+              teamCount(),
+              "team"
+            )} registered. Nothing changes until you confirm a proposal.`
+          : "Ask for pools, brackets, or a schedule. Nothing changes until you confirm a proposal."}
+      </p>
+      <div class="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
+        <For each={prompts()}>
+          {item => (
+            <button
+              type="button"
+              class="cursor-pointer rounded-lg border p-2.5 text-left transition-colors duration-150 hover:border-[color:var(--agent-line-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
+              style={{
+                "border-color": "var(--agent-line)",
+                "background-color": "var(--agent-raised)"
+              }}
+              disabled={props.disabled}
+              onClick={() => props.onPick(item.prompt)}
+            >
+              <div
+                class="text-xs font-medium leading-tight"
+                style={{ color: "var(--agent-ink)" }}
+              >
+                {item.title}
+              </div>
+              <div
+                class="mt-1 line-clamp-2 text-[11px] leading-tight"
+                style={{ color: "var(--agent-ink-muted)" }}
+              >
+                {item.prompt}
+              </div>
+            </button>
+          )}
+        </For>
+      </div>
+    </div>
+  );
+};
+
+const UserMessage = props => (
+  <div class="flex justify-end">
+    <div
+      class="max-w-[85%] rounded-2xl rounded-br-sm px-3.5 py-2 text-sm"
+      style={{
+        "background-color": "var(--agent-user-chip)",
+        color: "var(--agent-ink)"
+      }}
+    >
+      <p class="whitespace-pre-wrap">{props.content}</p>
+    </div>
+  </div>
+);
+
+/** Bubbleless assistant turn: the reply is the page, not a chat bubble. */
+const AssistantMessage = props => (
+  <div class="flex gap-3">
+    <AgentMark
+      class="mt-0.5 h-4 w-4 shrink-0"
+      style={{ color: "var(--agent-accent)" }}
+    />
+    <div class="min-w-0 flex-1">
+      <Show when={(props.toolEvents || []).length > 0}>
+        <ToolEventTimeline events={props.toolEvents} />
+      </Show>
+      <Show when={props.content}>
+        <div
+          class="text-[0.9375rem] leading-normal text-[color:var(--agent-ink)]"
+          classList={{ "agent-caret": props.streaming }}
+        >
+          <StyledMarkdown
+            markdown={props.content}
+            classMap={agentClassMap}
+            headingIds={false}
+          />
+        </div>
+      </Show>
+      <Show when={props.children}>
+        <div class="mt-3">{props.children}</div>
+      </Show>
+    </div>
+  </div>
+);
+
+const TournamentAgentTab = props => {
+  const [store] = useStore();
+  const queryClient = useQueryClient();
+  const [localTournamentId, setLocalTournamentId] = createSignal(
+    props.tournamentId || null
+  );
+  const [draft, setDraft] = createSignal("");
+  const [modelId, setModelId] = createSignal("");
+  const [optimisticUserMessages, setOptimisticUserMessages] = createSignal([]);
+  const [isAwaitingAgent, setIsAwaitingAgent] = createSignal(false);
+  const [streamingText, setStreamingText] = createSignal("");
+  const [streamingTools, setStreamingTools] = createSignal([]);
+  const [streamError, setStreamError] = createSignal("");
+  const [confirmErrors, setConfirmErrors] = createSignal({});
+  const [confirmingClear, setConfirmingClear] = createSignal(false);
+  const [liveProposals, setLiveProposals] = createSignal([]);
+  let messagesContainerRef;
+  let messagesEndRef;
+  let textareaRef;
+  let abortController;
+  let pinnedToBottom = true;
+
+  createEffect(() => {
+    if (props.tournamentId) setLocalTournamentId(props.tournamentId);
+  });
+
+  const tournamentsQuery = createQuery(() => ["tournaments"], fetchTournaments);
+  const manageableTournaments = () =>
+    filterManageableTournaments(tournamentsQuery.data, store?.data);
+  const teamsQuery = createQuery(() => ["teams"], fetchTeams);
+  const modelsQuery = createQuery(
+    () => ["tournament-agent", "models"],
+    fetchTournamentAgentModels
+  );
+
+  createEffect(() => {
+    const data = modelsQuery.data;
+    if (data?.default_model_id && !modelId()) setModelId(data.default_model_id);
+  });
+
+  const historyQuery = createQuery(
+    () => ["tournament-agent", "history", localTournamentId()],
+    () => fetchTournamentAgentHistory(localTournamentId()),
+    {
+      get enabled() {
+        return !!localTournamentId();
+      }
+    }
+  );
+
+  createEffect(() => {
+    const hist = historyQuery.data;
+    if (hist?.model_id) setModelId(hist.model_id);
+  });
+
+  const tournament = createMemo(() =>
+    (tournamentsQuery.data || []).find(t => t.id === localTournamentId())
+  );
+
+  const teamsMap = createMemo(() => {
+    const map = {};
+    for (const team of teamsQuery.data || []) map[team.id] = team.name;
+    return map;
+  });
+
+  /** Seed -> team name, for reading proposals without decoding ids. */
+  const seedToTeamName = seed => {
+    const seeding = tournament()?.current_seeding || {};
+    const teamId = seeding[String(seed)] ?? seeding[seed];
+    return teamId ? teamsMap()[teamId] : undefined;
+  };
+
+  const fieldName = fieldId => {
+    const fields = queryClient.getQueryData(["fields", localTournamentId()]);
+    return (Array.isArray(fields) ? fields : []).find(f => f.id === fieldId)
+      ?.name;
+  };
+
+  const invalidateTournamentQueries = () => {
+    const tid = localTournamentId();
+    if (!tid) return;
+    for (const key of [
+      "pools",
+      "brackets",
+      "matches",
+      "swiss-rounds",
+      "cross-pool",
+      "position-pools",
+      "fields"
+    ]) {
+      queryClient.invalidateQueries({ queryKey: [key, tid] });
+    }
+    queryClient.invalidateQueries({ queryKey: ["tournaments"] });
+    queryClient.invalidateQueries({
+      queryKey: ["tournament-agent", "history", tid]
+    });
+  };
+
+  const confirmMutation = createMutation({
+    mutationFn: proposalId => confirmTournamentAgentProposal(proposalId),
+    onSuccess: (_data, proposalId) => {
+      setConfirmErrors(prev => {
+        const next = { ...prev };
+        delete next[proposalId];
+        return next;
+      });
+      setLiveProposals([]);
+      invalidateTournamentQueries();
+      historyQuery.refetch();
+    },
+    onError: (err, proposalId) => {
+      // 400 means the plan cannot be applied. Retrying Confirm with the
+      // same payload will fail the same way — keep the card and show why.
+      setConfirmErrors(prev => ({
+        ...prev,
+        [proposalId]: err?.message || "Could not apply this proposal"
+      }));
+      historyQuery.refetch();
+    }
+  });
+
+  const rejectMutation = createMutation({
+    mutationFn: proposalId => rejectTournamentAgentProposal(proposalId),
+    onSuccess: () => {
+      setLiveProposals([]);
+      historyQuery.refetch();
+    }
+  });
+
+  const clearMutation = createMutation({
+    mutationFn: () => clearTournamentAgentHistory(localTournamentId()),
+    onSuccess: () => {
+      setOptimisticUserMessages([]);
+      setIsAwaitingAgent(false);
+      setConfirmingClear(false);
+      historyQuery.refetch();
+    }
+  });
+
+  const setModelMutation = createMutation({
+    mutationFn: mid =>
+      setTournamentAgentModel({
+        tournament_id: localTournamentId(),
+        model_id: mid
+      }),
+    onSuccess: () => historyQuery.refetch()
+  });
+
+  const inputLocked = () => isAwaitingAgent() || clearMutation.isPending;
+
+  const displayMessages = () => {
+    const server = historyQuery.data?.messages || [];
+    const optimistic = optimisticUserMessages();
+    if (!optimistic.length) return server;
+    const serverUserTexts = new Set(
+      server.filter(m => m.role === "user").map(m => (m.content || "").trim())
+    );
+    return [
+      ...server,
+      ...optimistic.filter(m => !serverUserTexts.has((m.content || "").trim()))
+    ];
+  };
+
+  const pendingProposals = () => {
+    const fromHistory = historyQuery.data?.pending_proposals || [];
+    const live = liveProposals();
+    if (!live.length) return fromHistory;
+    // A new turn's live cards must not hide still-pending cards from earlier
+    // turns — staff need every Confirm in view at once.
+    const byId = new Map(fromHistory.map(p => [p.id, p]));
+    for (const p of live) byId.set(p.id, p);
+    return [...byId.values()];
+  };
+
+  const proposalIdsOnMessage = msg => {
+    const ids = [];
+    for (const event of msg.payload?.tool_events || []) {
+      if (event.proposal_id) ids.push(event.proposal_id);
+    }
+    for (const id of msg.payload?.proposal_ids || []) ids.push(id);
+    return ids;
+  };
+
+  const proposalsForMessage = msg => {
+    const ids = new Set(proposalIdsOnMessage(msg));
+    return pendingProposals().filter(p => ids.has(p.id));
+  };
+
+  const unattachedProposals = () => {
+    const attached = new Set();
+    for (const msg of displayMessages()) {
+      for (const id of proposalIdsOnMessage(msg)) attached.add(id);
+    }
+    // Live cards render on the in-flight assistant message.
+    for (const proposal of liveProposals()) attached.add(proposal.id);
+    return pendingProposals().filter(p => !attached.has(p.id));
+  };
+
+  const scrollToBottom = (behavior = "smooth") => {
+    requestAnimationFrame(() => {
+      if (messagesEndRef)
+        messagesEndRef.scrollIntoView({ behavior, block: "end" });
+    });
+  };
+
+  /** Streaming must not yank the view if staff scrolled up to read. */
+  const onScroll = () => {
+    if (!messagesContainerRef) return;
+    const { scrollTop, scrollHeight, clientHeight } = messagesContainerRef;
+    pinnedToBottom = scrollHeight - scrollTop - clientHeight < 60;
+  };
+
+  createEffect(() => {
+    displayMessages().length;
+    historyQuery.dataUpdatedAt;
+    scrollToBottom("auto");
+  });
+
+  createEffect(() => {
+    streamingText();
+    streamingTools().length;
+    if (pinnedToBottom) scrollToBottom("auto");
+  });
+
+  const autosize = () => {
+    if (!textareaRef) return;
+    textareaRef.style.height = "auto";
+    textareaRef.style.height = `${Math.min(textareaRef.scrollHeight, 200)}px`;
+  };
+
+  const beginTurn = text => {
+    setStreamError("");
+    setStreamingText("");
+    setStreamingTools([]);
+    setLiveProposals([]);
+    setOptimisticUserMessages(prev => [
+      ...prev,
+      {
+        id: `opt-${Date.now()}`,
+        role: "user",
+        content: text,
+        message_kind: "text",
+        optimistic: true
+      }
+    ]);
+    setIsAwaitingAgent(true);
+    pinnedToBottom = true;
+    scrollToBottom("auto");
+  };
+
+  const endTurn = async () => {
+    try {
+      await historyQuery.refetch();
+      setOptimisticUserMessages([]);
+    } finally {
+      setIsAwaitingAgent(false);
+      setStreamingText("");
+      setStreamingTools([]);
+      setLiveProposals([]);
+      abortController = undefined;
+    }
+  };
+
+  /** Apply one SSE event to the in-flight turn. */
+  const handleEvent = ({ name, data }) => {
+    if (name === "text_delta") {
+      setStreamingText(prev => prev + data.text);
+    } else if (name === "text_replace") {
+      setStreamingText(data.text);
+    } else if (name === "tool_start") {
+      setStreamingTools(prev => [
+        ...prev,
+        {
+          name: data.name,
+          arguments: data.arguments,
+          status: "running",
+          summary: ""
+        }
+      ]);
+    } else if (name === "tool_end") {
+      setStreamingTools(prev =>
+        prev.map((t, i) => (i === data.index ? { ...t, ...data } : t))
+      );
+    } else if (name === "proposal") {
+      setLiveProposals(prev => keepLiveProposals(prev, data.proposal));
+    } else if (name === "error") {
+      setStreamError(data.message || "The agent failed");
+    }
+  };
+
+  const runStream = async (starter, fallbackText) => {
+    abortController = new AbortController();
+    try {
+      await starter(abortController.signal);
+      await endTurn();
+    } catch (err) {
+      const aborted = err?.name === "AbortError";
+      setOptimisticUserMessages(prev =>
+        prev.filter(m => !(m.optimistic && m.content === fallbackText))
+      );
+      setIsAwaitingAgent(false);
+      abortController = undefined;
+      if (aborted) {
+        // The turn ran server-side regardless; show whatever it committed.
+        await historyQuery.refetch();
+        setOptimisticUserMessages([]);
+      } else {
+        setStreamError(err?.message || "Failed to reach the agent");
+        if (fallbackText) setDraft(fallbackText);
+      }
+      setStreamingText("");
+      setStreamingTools([]);
+    }
+  };
+
+  /** Server-derived next move. Deliberately hidden when anything else is
+   *  already asking for the user's attention, or when they are mid-thought. */
+  const nextStep = createMemo(() => {
+    const step = historyQuery.data?.next_step;
+    if (!step) return null;
+    if (inputLocked() || isAwaitingAgent()) return null;
+    if (draft().trim()) return null;
+    if (pendingProposals().length > 0) return null;
+    if (historyQuery.data?.pending_question) return null;
+    return step;
+  });
+
+  const handleSend = async message => {
+    if (inputLocked()) return;
+    const text = (message ?? draft()).trim();
+    if (!text || !localTournamentId()) return;
+
+    setDraft("");
+    autosize();
+    beginTurn(text);
+    await runStream(
+      signal =>
+        streamTournamentAgentMessage({
+          tournament_id: localTournamentId(),
+          message: text,
+          model_id: modelId() || undefined,
+          signal,
+          onEvent: handleEvent
+        }),
+      text
+    );
+  };
+
+  const proposalCardProps = proposal => {
+    const error = confirmErrors()[proposal.id] || proposal.last_error || "";
+    return {
+      proposal,
+      confirming: confirmMutation.isPending,
+      rejecting: rejectMutation.isPending,
+      disabled: inputLocked(),
+      error,
+      seedToTeamName,
+      fieldName,
+      onConfirm: () => {
+        setConfirmErrors(prev => {
+          const next = { ...prev };
+          delete next[proposal.id];
+          return next;
+        });
+        confirmMutation.mutate(proposal.id);
+      },
+      onReject: () => rejectMutation.mutate(proposal.id),
+      onAskFix: error
+        ? () => handleSend(confirmFixPrompt(proposal, error))
+        : undefined
+    };
+  };
+
+  const handleAnswer = async body => {
+    if (inputLocked()) return;
+    const q = historyQuery.data?.pending_question;
+    if (!q) return;
+
+    const labels = (q.options || [])
+      .filter(o => (body.selected_ids || []).includes(o.id))
+      .map(o => o.label);
+    const answerText = body.skip
+      ? "(skipped)"
+      : [labels.join(", "), body.other_text].filter(Boolean).join(" — ") ||
+        "Answered";
+
+    beginTurn(answerText);
+    await runStream(
+      signal =>
+        streamTournamentAgentAnswer({
+          questionId: q.id,
+          body,
+          signal,
+          onEvent: handleEvent
+        }),
+      answerText
+    );
+  };
+
+  const handleStop = () => {
+    abortController?.abort();
+  };
+
+  const handleModelChange = mid => {
+    if (inputLocked()) return;
+    setModelId(mid);
+    if (localTournamentId()) setModelMutation.mutate(mid);
+  };
+
+  onCleanup(() => {
+    abortController?.abort();
+    setIsAwaitingAgent(false);
+  });
+
+  const isStreamingReply = () =>
+    isAwaitingAgent() && (streamingText() || streamingTools().length > 0);
+
+  return (
+    <div
+      class="agent-surface flex h-full min-h-0 flex-col gap-3 overflow-hidden rounded-2xl border p-4 leading-snug sm:p-5 lg:flex-row lg:gap-5"
+      style={{
+        "background-color": "var(--agent-canvas)",
+        "border-color": "var(--agent-line)"
+      }}
+    >
+      <div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        {/* Quiet chrome: identity and controls, no card frame. */}
+        <div
+          class="flex shrink-0 flex-wrap items-center gap-2 border-b px-0.5 pb-3.5"
+          style={{ "border-color": "var(--agent-line)" }}
+        >
+          <select
+            id="tournament-agent-tournament"
+            aria-label="Tournament"
+            class="h-9 min-w-[10rem] max-w-full flex-1 cursor-pointer rounded-lg border-0 bg-transparent px-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ color: "var(--agent-ink)" }}
+            value={localTournamentId() || ""}
+            disabled={inputLocked()}
+            onChange={e => {
+              const id = e.target.value ? parseInt(e.target.value) : null;
+              setLocalTournamentId(id);
+              setOptimisticUserMessages([]);
+              setIsAwaitingAgent(false);
+              setLiveProposals([]);
+              props.onSelectTournament?.(id);
+            }}
+          >
+            <option value="">Select a tournament…</option>
+            <For each={manageableTournaments()}>
+              {t => <option value={t.id}>{t.event?.title || t.id}</option>}
+            </For>
+          </select>
+
+          <div class="ml-auto flex items-center gap-1">
+            <ModelPicker
+              models={modelsQuery.data?.models || []}
+              value={modelId()}
+              disabled={inputLocked()}
+              onChange={handleModelChange}
+            />
+            <Show
+              when={!confirmingClear()}
+              fallback={
+                <div class="flex items-center gap-1">
+                  <button
+                    type="button"
+                    class="cursor-pointer rounded-md bg-red-700 px-2 py-1 text-xs font-medium text-white transition-colors duration-150 hover:bg-red-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+                    onClick={() => clearMutation.mutate()}
+                  >
+                    Clear chat?
+                  </button>
+                  <button
+                    type="button"
+                    class="cursor-pointer rounded-md px-2 py-1 text-xs transition-colors duration-150 hover:bg-black/[0.04] dark:hover:bg-white/[0.06]"
+                    style={{ color: "var(--agent-ink-muted)" }}
+                    onClick={() => setConfirmingClear(false)}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              }
+            >
+              <button
+                type="button"
+                class="cursor-pointer rounded-md px-2 py-1 text-xs transition-colors duration-150 hover:bg-black/[0.04] focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-white/[0.06]"
+                style={{ color: "var(--agent-ink-muted)" }}
+                disabled={!localTournamentId() || inputLocked()}
+                onClick={() => setConfirmingClear(true)}
+              >
+                Clear
+              </button>
+            </Show>
+          </div>
+        </div>
+
+        <Show
+          when={localTournamentId()}
+          fallback={
+            <div class="flex flex-1 items-center justify-center p-8">
+              <p class="text-sm" style={{ color: "var(--agent-ink-muted)" }}>
+                Select a tournament to start.
+              </p>
+            </div>
+          }
+        >
+          <div
+            ref={messagesContainerRef}
+            onScroll={onScroll}
+            class="min-h-0 flex-1 overflow-y-auto overscroll-contain px-1 py-4"
+          >
+            <Show
+              when={displayMessages().length > 0 || isAwaitingAgent()}
+              fallback={
+                <EmptyState
+                  tournament={tournament()}
+                  tournamentId={localTournamentId()}
+                  onPick={handleSend}
+                  disabled={inputLocked()}
+                />
+              }
+            >
+              <div class="mx-auto max-w-3xl space-y-5">
+                <For each={displayMessages()}>
+                  {msg => (
+                    <Show
+                      when={msg.role !== "user"}
+                      fallback={<UserMessage content={msg.content} />}
+                    >
+                      <AssistantMessage
+                        content={msg.content}
+                        toolEvents={msg.payload?.tool_events}
+                      >
+                        <Show
+                          when={
+                            msg.message_kind === "question" &&
+                            msg.payload?.question_id
+                          }
+                        >
+                          <Show
+                            when={
+                              historyQuery.data?.pending_question?.id ===
+                                msg.payload.question_id && !inputLocked()
+                            }
+                            fallback={
+                              <Show when={msg.payload?.question_snapshot}>
+                                <QuestionSnapshot
+                                  question={msg.payload.question_snapshot}
+                                />
+                              </Show>
+                            }
+                          >
+                            <QuestionCard
+                              question={historyQuery.data.pending_question}
+                              disabled={inputLocked()}
+                              onSubmit={handleAnswer}
+                            />
+                          </Show>
+                        </Show>
+                        <For each={proposalsForMessage(msg)}>
+                          {proposal => (
+                            <div class="mt-3">
+                              <ProposalCard {...proposalCardProps(proposal)} />
+                            </div>
+                          )}
+                        </For>
+                      </AssistantMessage>
+                    </Show>
+                  )}
+                </For>
+
+                <Show when={isStreamingReply()}>
+                  <AssistantMessage
+                    content={streamingText()}
+                    toolEvents={streamingTools()}
+                    streaming
+                  >
+                    <For each={liveProposals()}>
+                      {proposal => (
+                        <div class="mt-3">
+                          <ProposalCard {...proposalCardProps(proposal)} />
+                        </div>
+                      )}
+                    </For>
+                  </AssistantMessage>
+                </Show>
+
+                <Show when={isAwaitingAgent() && !isStreamingReply()}>
+                  <div class="flex items-center gap-3">
+                    <AgentMark
+                      class="h-4 w-4 shrink-0 animate-pulse"
+                      style={{ color: "var(--agent-accent)" }}
+                    />
+                    <span
+                      class="text-sm"
+                      style={{ color: "var(--agent-ink-muted)" }}
+                      aria-live="polite"
+                    >
+                      Thinking…
+                    </span>
+                  </div>
+                </Show>
+
+                <Show when={unattachedProposals().length > 0}>
+                  <div class="space-y-2">
+                    <h3
+                      class="text-xs font-semibold uppercase tracking-wide"
+                      style={{ color: "var(--agent-ink-muted)" }}
+                    >
+                      Awaiting your confirmation
+                    </h3>
+                    <For each={unattachedProposals()}>
+                      {proposal => (
+                        <ProposalCard {...proposalCardProps(proposal)} />
+                      )}
+                    </For>
+                  </div>
+                </Show>
+              </div>
+            </Show>
+            <div ref={messagesEndRef} />
+          </div>
+
+          <div class="shrink-0 px-1 pb-1 pt-2">
+            <div class="mx-auto max-w-3xl">
+              <Show when={streamError()}>
+                <div
+                  class="mb-2 flex items-center gap-2 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300"
+                  role="alert"
+                >
+                  <span class="flex-1">{streamError()}</span>
+                  <button
+                    type="button"
+                    class="cursor-pointer font-medium underline-offset-2 hover:underline"
+                    onClick={() => setStreamError("")}
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              </Show>
+
+              <Show when={nextStep()}>
+                {step => (
+                  <div class="mb-2 flex items-center gap-2">
+                    <span
+                      class="text-[11px] font-medium uppercase tracking-wide"
+                      style={{ color: "var(--agent-ink-muted)" }}
+                    >
+                      Next
+                    </span>
+                    <button
+                      type="button"
+                      title={step().why}
+                      class="cursor-pointer rounded-full border px-3 py-1 text-xs font-medium transition-colors duration-150 hover:border-[color:var(--agent-line-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                      style={{
+                        "border-color": "var(--agent-line)",
+                        "background-color": "var(--agent-raised)",
+                        color: "var(--agent-ink)"
+                      }}
+                      onClick={() => {
+                        setDraft(step().prompt);
+                        autosize();
+                        textareaRef?.focus();
+                      }}
+                    >
+                      {step().label}
+                    </button>
+                  </div>
+                )}
+              </Show>
+
+              <form
+                class="flex items-end rounded-xl border p-2 transition-shadow duration-150 focus-within:ring-2 focus-within:ring-blue-500/40"
+                style={{
+                  "border-color": "var(--agent-line-strong)",
+                  "background-color": "var(--agent-raised)"
+                }}
+                onSubmit={e => {
+                  e.preventDefault();
+                  handleSend();
+                }}
+              >
+                <textarea
+                  id="tournament-agent-chat"
+                  ref={textareaRef}
+                  rows="1"
+                  aria-label="Message the agent"
+                  class="max-h-[200px] min-h-[32px] min-w-0 flex-1 resize-none border-0 bg-transparent px-2 py-1.5 text-left text-sm focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50"
+                  style={{ color: "var(--agent-ink)" }}
+                  placeholder={
+                    historyQuery.data?.placeholder ||
+                    "Ask for pools, a bracket, or a schedule…"
+                  }
+                  value={draft()}
+                  disabled={inputLocked()}
+                  onInput={e => {
+                    setDraft(e.target.value);
+                    autosize();
+                  }}
+                  onKeyDown={e => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      handleSend();
+                    }
+                  }}
+                />
+                <Show
+                  when={!isAwaitingAgent()}
+                  fallback={
+                    <button
+                      type="button"
+                      class="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-lg transition-colors duration-150 hover:bg-black/[0.06] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-white/[0.08]"
+                      style={{ color: "var(--agent-ink)" }}
+                      onClick={handleStop}
+                      title="Stop"
+                    >
+                      <span class="h-2.5 w-2.5 rounded-[2px] bg-current" />
+                      <span class="sr-only">Stop</span>
+                    </button>
+                  }
+                >
+                  <button
+                    type="submit"
+                    class="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-lg bg-blue-700 text-white transition-colors duration-150 hover:bg-blue-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-30 dark:bg-blue-600 dark:hover:bg-blue-700"
+                    disabled={!draft().trim()}
+                  >
+                    <svg
+                      class="h-4 w-4"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path d="M3.4 2.6a1 1 0 0 0-1.3 1.2l1.8 5.5a1 1 0 0 0 .8.7l7 .9-7 .9a1 1 0 0 0-.8.7l-1.8 5.5a1 1 0 0 0 1.4 1.2l14-7a1 1 0 0 0 0-1.8l-14-7Z" />
+                    </svg>
+                    <span class="sr-only">Send</span>
+                  </button>
+                </Show>
+              </form>
+              <p
+                class="mt-1.5 px-1 text-[10px]"
+                style={{ color: "var(--agent-ink-muted)" }}
+              >
+                AI-generated. Enter to send, Shift+Enter for a new line. Nothing
+                is saved until you confirm a proposal.
+              </p>
+            </div>
+          </div>
+        </Show>
+      </div>
+
+      {/* Right rail: pending proposals over live tournament state. */}
+      <Show when={localTournamentId()}>
+        <aside
+          class="hidden min-h-0 shrink-0 flex-col gap-2 overflow-y-auto border-l pl-3 lg:flex lg:w-[22rem] xl:w-[24rem]"
+          style={{ "border-color": "var(--agent-line)" }}
+        >
+          <Show when={pendingProposals().length > 0}>
+            <section>
+              <h3
+                class="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide"
+                style={{ color: "var(--agent-ink-muted)" }}
+              >
+                Awaiting your confirmation
+                <span class="min-w-4 inline-flex h-4 items-center justify-center rounded-full bg-blue-600 px-1 text-[10px] font-semibold text-white">
+                  {pendingProposals().length}
+                </span>
+              </h3>
+              <div class="space-y-2">
+                <For each={pendingProposals()}>
+                  {proposal => (
+                    <ProposalCard {...proposalCardProps(proposal)} />
+                  )}
+                </For>
+              </div>
+            </section>
+          </Show>
+
+          <Show when={pendingProposals().length > 0}>
+            <hr class="my-2" style={{ "border-color": "var(--agent-line)" }} />
+          </Show>
+
+          <TournamentRail
+            tournamentId={localTournamentId()}
+            tournament={tournament()}
+            teamsMap={teamsMap()}
+            busy={inputLocked()}
+            nextStep={historyQuery.data?.next_step}
+            onPrompt={text => handleSend(text)}
+          />
+        </aside>
+      </Show>
+    </div>
+  );
+};
+
+export default TournamentAgentTab;

--- a/frontend/src/components/tournament-manager/agent/TournamentRail.js
+++ b/frontend/src/components/tournament-manager/agent/TournamentRail.js
@@ -1,0 +1,849 @@
+import { createQuery } from "@tanstack/solid-query";
+import { createMemo, createSignal, For, Show } from "solid-js";
+
+import {
+  fetchBrackets,
+  fetchCrossPool,
+  fetchFieldsByTournamentId,
+  fetchMatches,
+  fetchPools,
+  fetchPositionPools,
+  fetchSwissRounds
+} from "../../../queries";
+
+const STATUS_LABELS = {
+  DFT: "Draft",
+  SCH: "Scheduling",
+  LIV: "Live",
+  COM: "Completed"
+};
+
+const STATUS_TONE = {
+  DFT: "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300",
+  SCH: "bg-amber-100 text-amber-800 dark:bg-amber-900/60 dark:text-amber-300",
+  LIV: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/60 dark:text-emerald-300",
+  COM: "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400"
+};
+
+/** One visual language for the five stage types, reused by the grid + legend. */
+const STAGE = {
+  pool: {
+    label: "Pool",
+    dot: "bg-blue-500",
+    chip: "bg-blue-50 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200"
+  },
+  swiss: {
+    label: "Swiss",
+    dot: "bg-violet-500",
+    chip: "bg-violet-50 text-violet-800 dark:bg-violet-900/40 dark:text-violet-200"
+  },
+  cross: {
+    label: "Cross pool",
+    dot: "bg-teal-500",
+    chip: "bg-teal-50 text-teal-800 dark:bg-teal-900/40 dark:text-teal-200"
+  },
+  bracket: {
+    label: "Bracket",
+    dot: "bg-amber-500",
+    chip: "bg-amber-50 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+  },
+  position: {
+    label: "Position",
+    dot: "bg-rose-500",
+    chip: "bg-rose-50 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200"
+  }
+};
+
+const stageOf = m => {
+  if (m.pool) return { ...STAGE.pool, code: `Pool ${m.pool.name}` };
+  if (m.swiss_round)
+    return { ...STAGE.swiss, code: `Swiss ${m.swiss_round.name}` };
+  if (m.cross_pool) return { ...STAGE.cross, code: "Cross pool" };
+  if (m.bracket) return { ...STAGE.bracket, code: `Bracket ${m.bracket.name}` };
+  if (m.position_pool)
+    return { ...STAGE.position, code: `Position ${m.position_pool.name}` };
+  return null;
+};
+
+/** Timestamps are serialized with a Z suffix but are naive IST wall-clock. */
+const wallClock = iso => (iso ? String(iso).slice(11, 16) : "");
+const wallDate = iso => (iso ? String(iso).slice(0, 10) : "");
+
+const Arrow = () => (
+  <svg
+    class="h-3 w-3 shrink-0"
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    viewBox="0 0 12 12"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M2 6h8M6.5 2.5 10 6l-3.5 3.5"
+    />
+  </svg>
+);
+
+/** A button that hands a ready-made prompt to the agent (never mutates itself). */
+const ActionButton = props => (
+  <button
+    type="button"
+    disabled={props.disabled}
+    class="inline-flex cursor-pointer items-center gap-1 rounded-md border px-2 py-1 text-[11px] font-medium transition-colors duration-150 hover:bg-black/[0.04] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-white/[0.06]"
+    style={{
+      "border-color": "var(--agent-line-strong)",
+      color: "var(--agent-accent)"
+    }}
+    onClick={() => props.onClick?.()}
+  >
+    {props.children}
+    <Arrow />
+  </button>
+);
+
+const Section = props => {
+  const [open, setOpen] = createSignal(props.defaultOpen ?? true);
+  return (
+    <section
+      class="rounded-lg border"
+      style={{
+        "border-color": "var(--agent-line)",
+        "background-color": "var(--agent-raised)"
+      }}
+    >
+      <button
+        type="button"
+        class="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        onClick={() => setOpen(!open())}
+        aria-expanded={open()}
+      >
+        <h3
+          class="text-xs font-semibold uppercase tracking-wide"
+          style={{ color: "var(--agent-ink-muted)" }}
+        >
+          {props.title}
+        </h3>
+        <Show when={props.count != null}>
+          <span
+            class="rounded px-1.5 text-[10px] font-semibold tabular-nums"
+            style={{
+              "background-color": "var(--agent-user-chip)",
+              color: "var(--agent-ink-muted)"
+            }}
+          >
+            {props.count}
+          </span>
+        </Show>
+        <Show when={props.pill}>
+          <span
+            class={`rounded px-1.5 text-[10px] font-medium ${
+              props.pillClass || ""
+            }`}
+            style={
+              props.pillClass ? undefined : { color: "var(--agent-ink-muted)" }
+            }
+          >
+            {props.pill}
+          </span>
+        </Show>
+        <Show when={props.flag}>
+          <span
+            class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
+            aria-label="Needs attention"
+          />
+        </Show>
+        <svg
+          class={`ml-auto h-3 w-3 shrink-0 transition-transform duration-200 ${
+            open() ? "rotate-180" : ""
+          }`}
+          style={{ color: "var(--agent-ink-muted)" }}
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 10 6"
+        >
+          <path
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="m1 1 4 4 4-4"
+          />
+        </svg>
+      </button>
+      <Show when={open()}>
+        <div class="px-3 pb-3">{props.children}</div>
+      </Show>
+    </section>
+  );
+};
+
+/** A stage that isn't set up yet: one muted line + the prompt to create it. */
+const NotSetUp = props => (
+  <div class="flex flex-wrap items-center gap-2">
+    <span class="text-xs italic" style={{ color: "var(--agent-ink-muted)" }}>
+      Not set up
+    </span>
+    <Show when={props.action}>
+      <ActionButton disabled={props.disabled} onClick={props.onAction}>
+        {props.action}
+      </ActionButton>
+    </Show>
+  </div>
+);
+
+/** seed -> team name table from a seeding map ({"1": team_id, …}). */
+const SeedTable = props => (
+  <table class="w-full text-left text-[11px]">
+    <tbody>
+      <For each={Object.keys(props.seeding || {}).sort((a, b) => a - b)}>
+        {seed => (
+          <tr>
+            <td
+              class="w-6 py-0.5 tabular-nums"
+              style={{ color: "var(--agent-ink-muted)" }}
+            >
+              {seed}
+            </td>
+            <td class="truncate py-0.5" style={{ color: "var(--agent-ink)" }}>
+              {props.teamsMap?.[props.seeding[seed]] ||
+                `Team ${props.seeding[seed]}`}
+            </td>
+          </tr>
+        )}
+      </For>
+    </tbody>
+  </table>
+);
+
+/** A scheduled match in the grid, tinted + tagged by its stage. */
+const MatchCell = props => {
+  const st = () => stageOf(props.m);
+  const cls = () =>
+    "block truncate rounded px-1 py-0.5 text-[10px] " + (st()?.chip || "");
+  const title = () =>
+    `${st() ? st().code + " · " : ""}${props.m.name}` +
+    (props.m.field?.name ? ` · ${props.m.field.name}` : "");
+  return (
+    <span class={cls()} title={title()}>
+      {props.m.name}
+    </span>
+  );
+};
+
+/**
+ * Read-only live view of the tournament, ordered to follow the setup workflow
+ * and showing every stage type present-or-not (like the classic tab), so staff
+ * see the whole structure at once. It never mutates: where a step is incomplete
+ * it hands the agent a ready-made prompt, so the agent proposes and staff confirm.
+ */
+const TournamentRail = props => {
+  const tid = () => props.tournamentId;
+  const enabled = () => !!tid();
+  const query = (key, fn) =>
+    createQuery(
+      () => [key, tid()],
+      () => fn(tid()),
+      {
+        get enabled() {
+          return enabled();
+        }
+      }
+    );
+
+  const poolsQuery = query("pools", fetchPools);
+  const swissQuery = query("swiss-rounds", fetchSwissRounds);
+  const bracketsQuery = query("brackets", fetchBrackets);
+  const crossPoolQuery = query("cross-pool", fetchCrossPool);
+  const positionPoolsQuery = query("position-pools", fetchPositionPools);
+  const fieldsQuery = query("fields", fetchFieldsByTournamentId);
+  const matchesQuery = query("matches", fetchMatches);
+
+  // These endpoints answer with {message} instead of a list when empty.
+  const listOf = q => (Array.isArray(q.data) ? q.data : []);
+
+  const pools = () => listOf(poolsQuery);
+  const swissRounds = () => listOf(swissQuery);
+  const brackets = () => listOf(bracketsQuery);
+  const positionPools = () => listOf(positionPoolsQuery);
+  const fields = () => listOf(fieldsQuery);
+  const matches = () => listOf(matchesQuery);
+  const hasCrossPool = () => !!crossPoolQuery.data?.id;
+  const crossPoolMatches = () => matches().filter(m => m.cross_pool);
+
+  const scheduled = () => matches().filter(m => m.time && m.field);
+  const unscheduled = () => matches().filter(m => !m.time || !m.field);
+  const teamCount = () =>
+    Object.keys(props.tournament?.current_seeding || {}).length;
+  const tournamentSeeding = () =>
+    props.tournament?.current_seeding ||
+    props.tournament?.initial_seeding ||
+    {};
+  const status = () => props.tournament?.status;
+  const hasFormat = () => pools().length > 0 || swissRounds().length > 0;
+
+  const formatLabel = () => {
+    if (swissRounds().length) return `${swissRounds().length} swiss`;
+    if (pools().length)
+      return `${pools().length} pool${pools().length === 1 ? "" : "s"}`;
+    return "no format";
+  };
+
+  const prompt = text => props.onPrompt?.(text);
+
+  /** The next move, derived by the server from the same phase the tool gate uses.
+   *  This used to be computed here from separately fetched queries, which meant
+   *  the rail could suggest a format on a tournament with no fields — something
+   *  the agent now declines, because stage tools are not offered in NO_FIELDS. */
+  const nextStep = createMemo(() => {
+    const step = props.nextStep;
+    return step
+      ? { label: step.label, text: step.prompt, why: step.why }
+      : null;
+  });
+
+  /** Stage types actually present in the schedule, for the legend. */
+  const scheduleStages = () => {
+    const seen = {};
+    for (const m of scheduled()) {
+      const s = stageOf(m);
+      if (s) seen[s.label] = s;
+    }
+    return Object.values(seen);
+  };
+
+  /** Scheduled matches as one field x time grid per day. */
+  const scheduleDays = () => {
+    const byDay = {};
+    for (const m of scheduled()) {
+      const day = wallDate(m.time);
+      (byDay[day] = byDay[day] || []).push(m);
+    }
+
+    let cols = fields();
+    if (!cols.length) {
+      const seen = {};
+      for (const m of scheduled()) {
+        if (m.field) seen[m.field.id] = m.field;
+      }
+      cols = Object.values(seen);
+    }
+
+    return Object.keys(byDay)
+      .sort()
+      .map(day => {
+        const dayMatches = byDay[day];
+        const times = [
+          ...new Set(dayMatches.map(m => wallClock(m.time)))
+        ].sort();
+        // Indexed once per day: the grid asks for every time x field cell, and
+        // scanning the day's matches for each of them is quadratic in the size
+        // of the schedule.
+        const bySlot = new Map();
+        for (const m of dayMatches) {
+          bySlot.set(`${wallClock(m.time)}|${m.field?.id}`, m);
+        }
+        const cellAt = (time, fieldId) => bySlot.get(`${time}|${fieldId}`);
+        return { day, times, cols, cellAt };
+      });
+  };
+
+  return (
+    <div class="space-y-2">
+      <Section title="Snapshot">
+        <div class="mb-2 flex items-center gap-2">
+          <span
+            class={`rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+              STATUS_TONE[status()] || STATUS_TONE.DFT
+            }`}
+          >
+            {STATUS_LABELS[status()] || status()}
+          </span>
+          <span
+            class="truncate text-xs"
+            style={{ color: "var(--agent-ink-muted)" }}
+          >
+            {props.tournament?.event?.title}
+          </span>
+        </div>
+
+        <div class="text-xs" style={{ color: "var(--agent-ink)" }}>
+          <span class="font-semibold tabular-nums">{teamCount()}</span> teams
+          <span style={{ color: "var(--agent-line-strong)" }}> · </span>
+          <span class="font-semibold">{formatLabel()}</span>
+          <span style={{ color: "var(--agent-line-strong)" }}> · </span>
+          <span class="font-semibold">CP {hasCrossPool() ? "on" : "off"}</span>
+          <span style={{ color: "var(--agent-line-strong)" }}> · </span>
+          <span class="font-semibold tabular-nums">{fields().length}</span>{" "}
+          fields
+          <span style={{ color: "var(--agent-line-strong)" }}> · </span>
+          <span class="font-semibold tabular-nums">
+            {matches().length}
+          </span>{" "}
+          matches
+        </div>
+
+        <Show when={unscheduled().length > 0}>
+          <p class="mt-2 text-xs" style={{ color: "var(--agent-ink-muted)" }}>
+            {unscheduled().length} of {matches().length} not scheduled
+          </p>
+        </Show>
+
+        <Show when={nextStep()}>
+          <div
+            class="mt-3 rounded-lg border p-2.5"
+            style={{
+              "border-color": "rgb(37 99 235 / 0.35)",
+              "background-color": "var(--agent-canvas)"
+            }}
+          >
+            <div
+              class="mb-1.5 text-[10px] font-semibold uppercase tracking-wide"
+              style={{ color: "var(--agent-ink-muted)" }}
+            >
+              Next step
+            </div>
+            <ActionButton
+              disabled={props.busy}
+              onClick={() => prompt(nextStep().text)}
+            >
+              {nextStep().label}
+            </ActionButton>
+          </div>
+        </Show>
+      </Section>
+
+      <Section
+        title="Seeding"
+        count={teamCount() || undefined}
+        defaultOpen={teamCount() > 0}
+      >
+        <Show
+          when={teamCount() > 0}
+          fallback={
+            <NotSetUp
+              disabled={props.busy}
+              action="Set seeding"
+              onAction={() =>
+                prompt("Propose seeding for the registered teams")
+              }
+            />
+          }
+        >
+          <SeedTable seeding={tournamentSeeding()} teamsMap={props.teamsMap} />
+        </Show>
+      </Section>
+
+      <Section
+        title="Initial stage"
+        pill={
+          hasFormat() ? (swissRounds().length ? "Swiss" : "Pools") : undefined
+        }
+        flag={!hasFormat() && teamCount() > 0}
+      >
+        <Show
+          when={hasFormat()}
+          fallback={
+            <NotSetUp
+              disabled={props.busy}
+              action={teamCount() > 0 ? "Recommend a format" : undefined}
+              onAction={() =>
+                prompt(
+                  "Recommend pools or Swiss groups for the registered teams"
+                )
+              }
+            />
+          }
+        >
+          <Show when={pools().length > 0}>
+            <div class="grid grid-cols-2 gap-3">
+              <For each={pools()}>
+                {pool => (
+                  <div>
+                    <div
+                      class="mb-1 text-xs font-semibold"
+                      style={{ color: "var(--agent-ink)" }}
+                    >
+                      Pool {pool.name}
+                    </div>
+                    <SeedTable
+                      seeding={pool.initial_seeding}
+                      teamsMap={props.teamsMap}
+                    />
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
+          <Show when={swissRounds().length > 0}>
+            <For each={swissRounds()}>
+              {round => (
+                <div class="mb-2 last:mb-0">
+                  <div
+                    class="mb-1 text-xs font-semibold"
+                    style={{ color: "var(--agent-ink)" }}
+                  >
+                    Swiss {round.name}
+                    <span
+                      class="ml-1 font-normal"
+                      style={{ color: "var(--agent-ink-muted)" }}
+                    >
+                      · round {round.current_round}/{round.num_rounds}
+                    </span>
+                  </div>
+                  <SeedTable
+                    seeding={round.initial_seeding}
+                    teamsMap={props.teamsMap}
+                  />
+                </div>
+              )}
+            </For>
+          </Show>
+        </Show>
+      </Section>
+
+      <Section
+        title="Cross pool"
+        pill={hasCrossPool() ? "On" : "Off"}
+        pillClass={
+          hasCrossPool()
+            ? "bg-teal-50 text-teal-800 dark:bg-teal-900/40 dark:text-teal-200"
+            : "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400"
+        }
+        count={hasCrossPool() ? crossPoolMatches().length : undefined}
+        defaultOpen={hasCrossPool()}
+      >
+        <Show
+          when={hasCrossPool()}
+          fallback={
+            <NotSetUp
+              disabled={props.busy}
+              action={pools().length > 1 ? "Set up cross pool" : undefined}
+              onAction={() =>
+                prompt("Set up the cross pool matches after pools")
+              }
+            />
+          }
+        >
+          <p class="text-xs" style={{ color: "var(--agent-ink)" }}>
+            {crossPoolMatches().length} cross-pool match
+            {crossPoolMatches().length === 1 ? "" : "es"}
+          </p>
+        </Show>
+      </Section>
+
+      <Section
+        title="Brackets"
+        count={brackets().length || undefined}
+        defaultOpen={brackets().length > 0}
+      >
+        <Show
+          when={brackets().length > 0}
+          fallback={
+            <NotSetUp
+              disabled={props.busy}
+              action={hasFormat() ? "Draw a bracket" : undefined}
+              onAction={() =>
+                prompt(
+                  "Set up a 1-4 (or 1-8) bracket that includes the 3rd-place push-in, not just two semis and a final"
+                )
+              }
+            />
+          }
+        >
+          <div class="space-y-2">
+            <For each={brackets()}>
+              {b => (
+                <div>
+                  <div
+                    class="mb-1 text-xs font-semibold"
+                    style={{ color: "var(--agent-ink)" }}
+                  >
+                    Bracket {b.name}
+                  </div>
+                  <Show when={b.initial_seeding}>
+                    <SeedTable
+                      seeding={b.initial_seeding}
+                      teamsMap={props.teamsMap}
+                    />
+                  </Show>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </Section>
+
+      <Section
+        title="Position pools"
+        count={positionPools().length || undefined}
+        defaultOpen={positionPools().length > 0}
+      >
+        <Show
+          when={positionPools().length > 0}
+          fallback={
+            <NotSetUp
+              disabled={props.busy}
+              action={hasFormat() ? "Add position pools" : undefined}
+              onAction={() =>
+                prompt("Set up position pools for final rankings")
+              }
+            />
+          }
+        >
+          <div class="space-y-2">
+            <For each={positionPools()}>
+              {pp => (
+                <div>
+                  <div
+                    class="mb-1 text-xs font-semibold"
+                    style={{ color: "var(--agent-ink)" }}
+                  >
+                    Position pool {pp.name}
+                  </div>
+                  <Show when={pp.initial_seeding}>
+                    <SeedTable
+                      seeding={pp.initial_seeding}
+                      teamsMap={props.teamsMap}
+                    />
+                  </Show>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </Section>
+
+      <Section
+        title="Fields"
+        count={fields().length || undefined}
+        flag={fields().length === 0 && matches().length > 0}
+      >
+        <Show
+          when={fields().length > 0}
+          fallback={
+            <NotSetUp
+              disabled={props.busy}
+              action="Add a field"
+              onAction={() => prompt("Add a field to this tournament")}
+            />
+          }
+        >
+          <ul class="space-y-1">
+            <For each={fields()}>
+              {f => (
+                <li class="flex items-center gap-2 text-xs">
+                  <span style={{ color: "var(--agent-ink)" }}>{f.name}</span>
+                  <Show when={f.is_broadcasted}>
+                    <span class="rounded bg-blue-100 px-1 text-[10px] font-medium text-blue-800 dark:bg-blue-900/60 dark:text-blue-300">
+                      Broadcast
+                    </span>
+                  </Show>
+                </li>
+              )}
+            </For>
+          </ul>
+        </Show>
+      </Section>
+
+      <Section
+        title="Schedule"
+        count={`${scheduled().length}/${matches().length}`}
+        flag={unscheduled().length > 0}
+        defaultOpen={scheduled().length > 0}
+      >
+        <Show when={unscheduled().length > 0}>
+          <div class="mb-3 flex flex-wrap items-center gap-2">
+            <span class="text-xs" style={{ color: "var(--agent-ink-muted)" }}>
+              {unscheduled().length} not scheduled
+            </span>
+            <Show when={fields().length > 0}>
+              <ActionButton
+                disabled={props.busy}
+                onClick={() =>
+                  prompt(
+                    "Recommend a schedule for the matches that aren't scheduled yet"
+                  )
+                }
+              >
+                Schedule them
+              </ActionButton>
+            </Show>
+          </div>
+        </Show>
+
+        <Show
+          when={scheduled().length > 0}
+          fallback={
+            <Show when={unscheduled().length === 0}>
+              <p
+                class="text-xs italic"
+                style={{ color: "var(--agent-ink-muted)" }}
+              >
+                Nothing to schedule yet.
+              </p>
+            </Show>
+          }
+        >
+          <div class="space-y-3">
+            <Show when={scheduleStages().length > 0}>
+              <div class="flex flex-wrap gap-x-3 gap-y-1">
+                <For each={scheduleStages()}>
+                  {s => (
+                    <span
+                      class="flex items-center gap-1 text-[10px]"
+                      style={{ color: "var(--agent-ink-muted)" }}
+                    >
+                      <span class={`h-2 w-2 rounded-full ${s.dot}`} />
+                      {s.label}
+                    </span>
+                  )}
+                </For>
+              </div>
+            </Show>
+
+            <For each={scheduleDays()}>
+              {day => (
+                <div>
+                  <div
+                    class="mb-1 text-[11px] font-semibold"
+                    style={{ color: "var(--agent-ink-muted)" }}
+                  >
+                    {day.day}
+                  </div>
+                  <div class="overflow-x-auto">
+                    <table class="w-full border-collapse text-[11px]">
+                      <thead>
+                        <tr>
+                          <th class="w-10" />
+                          <For each={day.cols}>
+                            {f => (
+                              <th
+                                class="border-b px-1.5 py-1 text-left font-medium"
+                                style={{
+                                  "border-color": "var(--agent-line)",
+                                  color: "var(--agent-ink-muted)"
+                                }}
+                              >
+                                {f.name}
+                              </th>
+                            )}
+                          </For>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <For each={day.times}>
+                          {time => (
+                            <tr>
+                              <td
+                                class="py-1 pr-1.5 align-top tabular-nums"
+                                style={{ color: "var(--agent-ink-muted)" }}
+                              >
+                                {time}
+                              </td>
+                              <For each={day.cols}>
+                                {f => (
+                                  <td
+                                    class="border-t px-1 py-1 align-top"
+                                    style={{
+                                      "border-color": "var(--agent-line)"
+                                    }}
+                                  >
+                                    <Show
+                                      when={day.cellAt(time, f.id)}
+                                      fallback={
+                                        <span
+                                          style={{
+                                            color: "var(--agent-line-strong)"
+                                          }}
+                                        >
+                                          ·
+                                        </span>
+                                      }
+                                    >
+                                      <MatchCell m={day.cellAt(time, f.id)} />
+                                    </Show>
+                                  </td>
+                                )}
+                              </For>
+                            </tr>
+                          )}
+                        </For>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </Section>
+
+      <Show when={status() === "LIV" || status() === "COM"}>
+        <Section title="Standings" defaultOpen={false}>
+          <Show
+            when={pools().length > 0}
+            fallback={
+              <p
+                class="text-xs italic"
+                style={{ color: "var(--agent-ink-muted)" }}
+              >
+                No pool standings yet.
+              </p>
+            }
+          >
+            <For each={pools()}>
+              {pool => (
+                <div class="mb-2 last:mb-0">
+                  <div
+                    class="mb-1 text-xs font-semibold"
+                    style={{ color: "var(--agent-ink)" }}
+                  >
+                    Pool {pool.name}
+                  </div>
+                  <table class="w-full text-left text-[11px]">
+                    <tbody>
+                      <For
+                        each={Object.entries(pool.results || {}).sort(
+                          (a, b) => (a[1].rank || 99) - (b[1].rank || 99)
+                        )}
+                      >
+                        {([teamId, res]) => (
+                          <tr>
+                            <td
+                              class="w-5 py-0.5 tabular-nums"
+                              style={{ color: "var(--agent-ink-muted)" }}
+                            >
+                              {res.rank}
+                            </td>
+                            <td
+                              class="truncate py-0.5"
+                              style={{ color: "var(--agent-ink)" }}
+                            >
+                              {props.teamsMap?.[teamId] || `Team ${teamId}`}
+                            </td>
+                            <td
+                              class="w-10 py-0.5 text-right tabular-nums"
+                              style={{ color: "var(--agent-ink-muted)" }}
+                            >
+                              {res.wins}-{res.losses}
+                            </td>
+                          </tr>
+                        )}
+                      </For>
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </For>
+          </Show>
+        </Section>
+      </Show>
+    </div>
+  );
+};
+
+export default TournamentRail;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -291,3 +291,60 @@ dialog[open]::backdrop {
     background-color: rgb(55 65 81 / 0.9);
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Tournament agent surface
+ *
+ * The agent tab is deliberately its own surface: a warm paper canvas instead of
+ * the app's cool gray, so a conversation reads as a document rather than a form.
+ * Tokens live here (not Tailwind config) to keep the change contained.
+ * ------------------------------------------------------------------------- */
+
+.agent-surface {
+  --agent-canvas: #faf9f7;
+  --agent-raised: #ffffff;
+  --agent-ink: #1f1d1a;
+  --agent-ink-muted: #6b6660;
+  --agent-line: #e7e3dd;
+  --agent-line-strong: #d6d1c8;
+  --agent-accent: #1d4ed8;
+  --agent-user-chip: #f1efe9;
+}
+
+.dark .agent-surface {
+  --agent-canvas: #1a1917;
+  --agent-raised: #232220;
+  --agent-ink: #ece9e4;
+  --agent-ink-muted: #9d968c;
+  --agent-line: #35332f;
+  --agent-line-strong: #454239;
+  --agent-accent: #93c5fd;
+  --agent-user-chip: #2b2926;
+}
+
+/* Streaming caret: marks the live reply without shifting layout. A pseudo-element
+ * can't be expressed as a utility class, so it lives here; all agent markdown
+ * styling is Tailwind, applied via agentClassMap in TournamentAgentTab. */
+.agent-caret::after {
+  content: "";
+  display: inline-block;
+  width: 0.45em;
+  height: 1.05em;
+  margin-left: 0.12em;
+  vertical-align: text-bottom;
+  background-color: currentColor;
+  opacity: 0.6;
+  animation: agent-caret-blink 1.1s steps(2, start) infinite;
+}
+
+@keyframes agent-caret-blink {
+  to {
+    visibility: hidden;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-caret::after {
+    animation: none;
+  }
+}

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -140,6 +140,55 @@ export const searchUsers = async searchText => {
   return await response.json();
 };
 
+export const fetchTournamentDirectors = async tournamentId => {
+  const response = await fetch(`/api/tournament/${tournamentId}/directors`, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+    credentials: "same-origin"
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || JSON.stringify(data));
+  }
+  return data;
+};
+
+export const addTournamentDirector = async ({ tournamentId, userId }) => {
+  const response = await fetch(`/api/tournament/${tournamentId}/directors`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": getCookie("csrftoken")
+    },
+    credentials: "same-origin",
+    body: JSON.stringify({ user_id: userId })
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || JSON.stringify(data));
+  }
+  return data;
+};
+
+export const removeTournamentDirector = async ({ tournamentId, userId }) => {
+  const response = await fetch(
+    `/api/tournament/${tournamentId}/directors/${userId}`,
+    {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": getCookie("csrftoken")
+      },
+      credentials: "same-origin"
+    }
+  );
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || JSON.stringify(data));
+  }
+  return data;
+};
+
 export const searchPlayers = async (searchText, pagination) => {
   let baseUrl = "/api/players/search";
   let params = new URLSearchParams();
@@ -1084,6 +1133,23 @@ export const updateField = async ({ field_id, body }) => {
     },
     credentials: "same-origin",
     body: JSON.stringify(body)
+  });
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data?.message || JSON.stringify(data));
+  }
+
+  return data;
+};
+
+export const deleteField = async ({ field_id }) => {
+  const response = await fetch(`/api/tournament/field/${field_id}`, {
+    method: "DELETE",
+    headers: {
+      "X-CSRFToken": getCookie("csrftoken")
+    },
+    credentials: "same-origin"
   });
   const data = await response.json();
 
@@ -2255,4 +2321,241 @@ export const fetchMyFormResponses = async slug => {
     return [];
   }
   return await response.json();
+};
+
+// Tournament Agent API
+export const fetchTournamentAgentModels = async () => {
+  const response = await fetch("/api/tournament-agent/models", {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+    credentials: "same-origin"
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || "Failed to fetch models");
+  }
+  return data;
+};
+
+export const fetchTournamentAgentHistory = async tournamentId => {
+  const response = await fetch(
+    `/api/tournament-agent/history?tournament_id=${tournamentId}`,
+    {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+      credentials: "same-origin"
+    }
+  );
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || "Failed to fetch agent history");
+  }
+  return data;
+};
+
+export const sendTournamentAgentMessage = async ({
+  tournament_id,
+  message,
+  model_id
+}) => {
+  const response = await fetch("/api/tournament-agent/send_message", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": getCookie("csrftoken")
+    },
+    credentials: "same-origin",
+    body: JSON.stringify({ tournament_id, message, model_id })
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || "Failed to send message");
+  }
+  return data;
+};
+
+/**
+ * Consume a Server-Sent Events response body, invoking onEvent per frame.
+ *
+ * EventSource is not usable here: it is GET-only and cannot send the CSRF
+ * header, so we read the fetch body and parse the frames ourselves.
+ */
+const consumeSSE = async (response, onEvent) => {
+  if (!response.body) {
+    throw new Error("Streaming is not supported by this browser");
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  const dispatch = frame => {
+    let name = "message";
+    const dataLines = [];
+    for (const line of frame.split("\n")) {
+      if (line.startsWith("event:")) name = line.slice(6).trim();
+      else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+    }
+    if (!dataLines.length) return;
+    try {
+      onEvent({ name, data: JSON.parse(dataLines.join("\n")) });
+    } catch (e) {
+      // A malformed frame should not tear down the rest of the turn.
+    }
+  };
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    // Frames are separated by a blank line; the tail may be a partial frame.
+    const frames = buffer.split("\n\n");
+    buffer = frames.pop() ?? "";
+    frames.forEach(dispatch);
+  }
+  if (buffer.trim()) dispatch(buffer);
+};
+
+const streamAgentRequest = async (url, body, { signal, onEvent }) => {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": getCookie("csrftoken")
+    },
+    credentials: "same-origin",
+    body: JSON.stringify(body),
+    signal
+  });
+  if (!response.ok) {
+    // Failures before the turn starts are real status codes carrying one frame.
+    let message = `Request failed (${response.status})`;
+    try {
+      const text = await response.text();
+      const match = text.match(/data: (.+)/);
+      if (match) message = JSON.parse(match[1]).message || message;
+    } catch (e) {
+      // fall through to the generic message
+    }
+    throw new Error(message);
+  }
+  await consumeSSE(response, onEvent);
+};
+
+export const streamTournamentAgentMessage = ({
+  tournament_id,
+  message,
+  model_id,
+  signal,
+  onEvent
+}) =>
+  streamAgentRequest(
+    "/api/tournament-agent/stream_message",
+    { tournament_id, message, model_id },
+    { signal, onEvent }
+  );
+
+export const streamTournamentAgentAnswer = ({
+  questionId,
+  body,
+  signal,
+  onEvent
+}) =>
+  streamAgentRequest(
+    `/api/tournament-agent/questions/${questionId}/answer_stream`,
+    body,
+    { signal, onEvent }
+  );
+
+export const answerTournamentAgentQuestion = async (questionId, body) => {
+  const response = await fetch(
+    `/api/tournament-agent/questions/${questionId}/answer`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": getCookie("csrftoken")
+      },
+      credentials: "same-origin",
+      body: JSON.stringify(body)
+    }
+  );
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || "Failed to answer question");
+  }
+  return data;
+};
+
+export const confirmTournamentAgentProposal = async proposalId => {
+  const response = await fetch(
+    `/api/tournament-agent/proposals/${proposalId}/confirm`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": getCookie("csrftoken")
+      },
+      credentials: "same-origin"
+    }
+  );
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || "Failed to confirm proposal");
+  }
+  return data;
+};
+
+export const rejectTournamentAgentProposal = async proposalId => {
+  const response = await fetch(
+    `/api/tournament-agent/proposals/${proposalId}/reject`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": getCookie("csrftoken")
+      },
+      credentials: "same-origin"
+    }
+  );
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || "Failed to reject proposal");
+  }
+  return data;
+};
+
+export const setTournamentAgentModel = async ({ tournament_id, model_id }) => {
+  const response = await fetch("/api/tournament-agent/set_model", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": getCookie("csrftoken")
+    },
+    credentials: "same-origin",
+    body: JSON.stringify({ tournament_id, model_id })
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || "Failed to set model");
+  }
+  return data;
+};
+
+export const clearTournamentAgentHistory = async tournamentId => {
+  const response = await fetch(
+    `/api/tournament-agent/clear_history?tournament_id=${tournamentId}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": getCookie("csrftoken")
+      },
+      credentials: "same-origin"
+    }
+  );
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || "Failed to clear history");
+  }
+  return data;
 };

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -2293,6 +2293,24 @@ export const fetchFormResponses = async slug => {
   return await response.json();
 };
 
+export const downloadFormResponsesCsv = async slug => {
+  const response = await fetch(`/api/forms/${slug}/responses/csv`, {
+    method: "GET",
+    credentials: "same-origin"
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data?.message || "Failed to download responses");
+  }
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${slug}-responses.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
 export const fetchMyFormResponses = async slug => {
   const response = await fetch(`/api/forms/${slug}/my-responses`, {
     method: "GET",
@@ -2394,6 +2412,9 @@ const consumeSSE = async (response, onEvent) => {
     buffer = frames.pop() ?? "";
     frames.forEach(dispatch);
   }
+  // Flush: a multi-byte character split across the last two chunks is still
+  // held inside the decoder, and player names and em dashes are full of them.
+  buffer += decoder.decode();
   if (buffer.trim()) dispatch(buffer);
 };
 

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -2293,24 +2293,6 @@ export const fetchFormResponses = async slug => {
   return await response.json();
 };
 
-export const downloadFormResponsesCsv = async slug => {
-  const response = await fetch(`/api/forms/${slug}/responses/csv`, {
-    method: "GET",
-    credentials: "same-origin"
-  });
-  if (!response.ok) {
-    const data = await response.json().catch(() => ({}));
-    throw new Error(data?.message || "Failed to download responses");
-  }
-  const blob = await response.blob();
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = `${slug}-responses.csv`;
-  a.click();
-  URL.revokeObjectURL(url);
-};
-
 export const fetchMyFormResponses = async slug => {
   const response = await fetch(`/api/forms/${slug}/my-responses`, {
     method: "GET",

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -17,6 +17,16 @@ export const getCookie = name => {
   return cookies[name];
 };
 
+export const canManageTournaments = user =>
+  Boolean(user?.is_staff || (user?.directed_tournament_ids || []).length);
+
+export const filterManageableTournaments = (tournaments, user) => {
+  if (!user) return [];
+  if (user.is_staff) return tournaments || [];
+  const ids = new Set(user.directed_tournament_ids || []);
+  return (tournaments || []).filter(t => ids.has(t.id));
+};
+
 export const fetchUserData = (successCallback, failureCallback) => {
   return fetch("/api/me", {
     method: "GET",


### PR DESCRIPTION
The UI for the tournament manager agent, in four commits:

1. **Move `TournamentManager` into its own directory as the classic tab.**
   A pure rename with the import repointed, so the commit that adds the
   agent tab is not buried under 2,000 lines of relocated code. Git detects
   the rename — the real diff is ~130 lines.
2. `StyledMarkdown` restyles on update and takes a custom class map.
3. Directors can manage the tournaments they are assigned to (UI half of
   the backend change in #555).
4. The agent tab itself.

What to review: a proposal renders as a card showing what would change,
with Confirm and Reject, so nothing reaches the tournament without a
person agreeing. Questions render as typed options rather than free text,
kept as snapshots so a reloaded thread still shows what was asked. The
tool timeline shows what the agent actually did.