### PR TITLE
Fix the shared-CPU exhaustion behind the 2026-08-28 outage

### DIFF
--- a/.github/workflows/autoscale-guard.yml
+++ b/.github/workflows/autoscale-guard.yml
@@ -1,0 +1,51 @@
+---
+name: Autoscale Guard
+# Warns when the shared-CPU burst balance is draining. It does not remediate: Fly
+# Scale only opens a PR, so a human still merges it and runs Fly Deploy. Backtested
+# on the 2026-08-28 incident the warning lands ~5h before the first 504.
+#
+# Scheduled workflows only run on the default branch, so this is inert until merged.
+on:
+  # The signal is a 2-hour window, so polling faster buys nothing.
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: fly-autoscale-guard
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check burst balance
+    runs-on: ubuntu-latest
+    outputs:
+      escalate: ${{ steps.check.outputs.escalate }}
+      reason: ${{ steps.check.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read cpu_balance
+        id: check
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: python3 scripts/check-scale.py
+
+      - name: Summary
+        env:
+          REASON: ${{ steps.check.outputs.reason }}
+        run: |
+          echo "Autoscale guard: $REASON" >> "$GITHUB_STEP_SUMMARY"
+
+  escalate:
+    name: Open a tournament-profile PR
+    needs: check
+    if: ${{ needs.check.outputs.escalate == 'true' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/scale.yml
+    with:
+      profile: tournament
+      reason: ${{ needs.check.outputs.reason }}
+    secrets: inherit

--- a/.github/workflows/scale.yml
+++ b/.github/workflows/scale.yml
@@ -1,70 +1,124 @@
 ---
 name: Fly Scale
+# Applies a scaling profile from deploy/profiles.json and opens a PR against main.
+# Never deploys: merging the PR and running Fly Deploy are both human steps.
 on:
   workflow_dispatch:
     inputs:
-      cpu:
+      profile:
         type: choice
-        description: CPU Size
+        description: Scaling profile (see deploy/profiles.json)
+        required: true
+        default: baseline
         options:
-          - 2
-          - 4
-          - 8
-      gunicorn:
-        type: choice
-        description: Gunicorn servers
-        options:
-          - 4
-          - 8
-          - 12
-      hardLimit:
-        type: choice
-        description: Hard limit on connections
-        options:
-          - 100
-          - 200
-          - 400
-      softLimit:
-        type: choice
-        description: Soft limit on connections
-        options:
-          - 75
-          - 150
-          - 300
+          - baseline
+          - tournament
+          - peak
+  workflow_call:
+    inputs:
+      profile:
+        type: string
+        required: true
+      reason:
+        type: string
+        required: false
+        default: Requested manually
+    secrets:
+      ZULIP_API_KEY:
+        required: false
+
+concurrency:
+  group: fly-scale
+  cancel-in-progress: false
+
 jobs:
   scale:
-    name: Scale up or down hub
+    name: Open scaling PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      TARGET_BRANCH: main
+      # Job level, so the step's `if` can read it.
+      ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Replace cpu size
-        uses: jacobtomlinson/gha-find-replace@v3
+      - uses: actions/checkout@v4
         with:
-          find: "cpus = [0-9]+"
-          replace: "cpus = ${{github.event.inputs.cpu}}"
-          include: "fly.toml"
-      - name: Replace gunicorn servers
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "-w [0-9]+"
-          replace: "-w ${{github.event.inputs.gunicorn}}"
-          include: "deploy/start.sh"
-      - name: Replace hard limit
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "hard_limit = [0-9]+"
-          replace: "hard_limit = ${{github.event.inputs.hardLimit}}"
-          include: "fly.toml"
-      - name: Replace soft limit
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "soft_limit = [0-9]+"
-          replace: "soft_limit = ${{github.event.inputs.softLimit}}"
-          include: "fly.toml"
-      - name: Get current unix timestamp
-        id: timestamp
-        uses: release-kit/unix-timestamp@v1
-      - uses: EndBug/add-and-commit@v9
-        with:
-          new_branch: fly-scale-${{steps.timestamp.outputs.timestamp}}
-          message: "vm: Scale"
+          ref: main
+
+      - name: Apply profile
+        env:
+          PROFILE: ${{ inputs.profile }}
+        run: |
+          python3 scripts/apply-profile.py "$PROFILE" | tee scale-summary.txt
+
+      - name: Detect change
+        id: change
+        env:
+          PROFILE: ${{ inputs.profile }}
+        run: |
+          if git diff --quiet -- fly.toml; then
+            echo "main is already on the $PROFILE profile; nothing to open."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open the PR
+        id: pr
+        if: ${{ steps.change.outputs.changed == 'true' }}
+        env:
+          PROFILE: ${{ inputs.profile }}
+          REASON: ${{ inputs.reason || 'Requested manually' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="fly-scale/$PROFILE-$(date -u +%Y%m%d-%H%M%S)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add fly.toml
+          git commit -m "deploy: Scale to the $PROFILE profile"
+          git push origin "$BRANCH"
+          BODY="Why: $REASON
+
+          $(cat scale-summary.txt)
+
+          Nothing is deployed yet. Merge this, then run the Fly Deploy workflow."
+          PR_URL=$(gh pr create --base "$TARGET_BRANCH" --head "$BRANCH" \
+            --title "deploy: Scale to the $PROFILE profile" --body "$BODY")
+          echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "Opened $PR_URL"
+
+      - name: Notify Zulip
+        if: ${{ steps.change.outputs.changed == 'true' && env.ZULIP_API_KEY != '' }}
+        continue-on-error: true
+        env:
+          PROFILE: ${{ inputs.profile }}
+          REASON: ${{ inputs.reason || 'Requested manually' }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          MESSAGE="Scaling PR opened: **$PROFILE**
+
+          $REASON
+
+          Not deployed yet -- merge and run Fly Deploy. [Review the PR]($PR_URL)"
+          curl -s -X POST "https://upai.zulipchat.com/api/v1/messages" \
+            -u "github-bot@upai.zulipchat.com:$ZULIP_API_KEY" \
+            -d "type=stream" \
+            -d "to=tech%20backend" \
+            -d "subject=Scaling" \
+            --data-urlencode "content=$MESSAGE"
+
+      - name: Summary
+        if: ${{ always() }}
+        run: |
+          {
+            echo "### Fly scale"
+            echo
+            cat scale-summary.txt 2>/dev/null || echo "profile was not applied"
+            echo
+            echo "- changed: ${{ steps.change.outputs.changed }}"
+            echo "- PR: ${{ steps.pr.outputs.url || 'none opened' }}"
+            echo "- deployed: no (merge the PR, then run Fly Deploy)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -7,8 +7,23 @@ server {
     access_log  /var/log/nginx/hub.log;
     root /var/www/hub/;
 
+    # Debian defaults gzip_types to text/html, so the bundles went out uncompressed.
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types application/javascript text/css application/json image/svg+xml;
+
+    # Content-hashed names, so a cached copy can never be the wrong one. index.html
+    # is rendered by Django per request and always names the current hashes.
+    location ~ "^/static/(.*\.)?[0-9a-f]{12,32}\.[a-zA-Z0-9]+$" {
+        root /var/www/hub;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # Unhashed names (assets/favico.png, used by LOGO_URL and the favicon alias).
     location /static/ {
         root /var/www/hub;
+        add_header Cache-Control "public, max-age=3600, must-revalidate";
     }
 
     location /media/ {

--- a/deploy/profiles.json
+++ b/deploy/profiles.json
@@ -1,0 +1,32 @@
+{
+  "baseline": {
+    "description": "Everyday traffic. Shared CPU, bursts to 4 cores for spikes.",
+    "cpu_kind": "shared",
+    "cpus": 4,
+    "memory": "2gb",
+    "workers": 6,
+    "threads": 6,
+    "soft_limit": 36,
+    "hard_limit": 72
+  },
+  "tournament": {
+    "description": "Tournament days. Dedicated CPU, so the burst balance cannot run out.",
+    "cpu_kind": "performance",
+    "cpus": 1,
+    "memory": "2gb",
+    "workers": 2,
+    "threads": 12,
+    "soft_limit": 24,
+    "hard_limit": 48
+  },
+  "peak": {
+    "description": "Finals or anything unusual. Twice the tournament headroom.",
+    "cpu_kind": "performance",
+    "cpus": 2,
+    "memory": "4gb",
+    "workers": 4,
+    "threads": 8,
+    "soft_limit": 32,
+    "hard_limit": 64
+  }
+}

--- a/deploy/start.sh
+++ b/deploy/start.sh
@@ -26,4 +26,6 @@ export PATH="$HOME/.local/bin:$PATH"
 # with 2 sync workers a single stream would eat half the server. The default 30s
 # timeout also kills turns long before the model is done, so raise it past the
 # provider's own 120s ceiling.
-gunicorn -w 4 -k gthread --threads 6 --timeout 300 --graceful-timeout 25 hub.wsgi
+# Counts come from fly.toml [env], set by scripts/apply-profile.py.
+gunicorn -w "${GUNICORN_WORKERS:-6}" -k gthread --threads "${GUNICORN_THREADS:-6}" \
+  --timeout 300 --graceful-timeout 25 hub.wsgi

--- a/fly.toml
+++ b/fly.toml
@@ -21,11 +21,14 @@ swap_size_mb = 512
 [env]
   PORT = "8000"
   DJANGO_SETTINGS_MODULE = "hub.production"
+  # Set by scripts/apply-profile.py; workers x threads must track the limits below.
+  GUNICORN_WORKERS = "6"
+  GUNICORN_THREADS = "6"
 
 [[vm]]
   cpu_kind = "shared"
   cpus = 4
-  memory = "1gb"
+  memory = "2gb"
 
 [[services]]
   protocol = "tcp"
@@ -42,8 +45,8 @@ swap_size_mb = 512
     handlers = ["tls", "http"]
   [services.concurrency]
     type = "connections"
-    hard_limit = 200
-    soft_limit = 150
+    hard_limit = 72
+    soft_limit = 36
 
   [[services.tcp_checks]]
     interval = "15s"

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -1,4 +1,4 @@
-import { getCookie } from "./utils";
+import { getCookie, hasAuthHint } from "./utils";
 
 export const fetchContributors = async () => {
   const repoResp = await fetch(
@@ -699,6 +699,16 @@ export const fetchTournamentTeamPointsBySlugV2 = async (
 };
 
 export const fetchUserAccessByTournamentSlug = async tournament_slug => {
+  if (!hasAuthHint()) {
+    return {
+      is_staff: false,
+      is_tournament_admin: false,
+      is_tournament_director: false,
+      is_tournament_volunteer: false,
+      playing_team_id: null,
+      admin_team_ids: []
+    };
+  }
   const response = await fetch(
     `/api/me/access?tournament_slug=${tournament_slug}`,
     {
@@ -711,6 +721,9 @@ export const fetchUserAccessByTournamentSlug = async tournament_slug => {
 };
 
 export const fetchUser = async () => {
+  if (!hasAuthHint()) {
+    throw new Error("Not authenticated");
+  }
   const response = await fetch("/api/me", {
     method: "GET",
     headers: { "Content-Type": "application/json" },
@@ -726,6 +739,10 @@ export const fetchUser = async () => {
 };
 
 export const fetchUserRegistrations = async () => {
+  // Same empty list the API returns for a user with no player profile.
+  if (!hasAuthHint()) {
+    return [];
+  }
   const response = await fetch("/api/me/registrations", {
     method: "GET",
     headers: { "Content-Type": "application/json" },
@@ -2101,6 +2118,10 @@ export const clearChatHistory = async () => {
 };
 
 export const fetchMembershipStatus = async () => {
+  // Same shape the API returns for a user with no membership.
+  if (!hasAuthHint()) {
+    return { has_membership: false, is_active: false };
+  }
   const response = await fetch("/api/me/membership", {
     method: "GET",
     headers: { "Content-Type": "application/json" },

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -17,6 +17,10 @@ export const getCookie = name => {
   return cookies[name];
 };
 
+// Mirror of the HttpOnly session cookie, set by AuthHintCookieMiddleware, so the
+// SPA can tell it is signed out without taking a 401. A hint, not an auth check.
+export const hasAuthHint = () => getCookie("hub_auth") === "1";
+
 export const canManageTournaments = user =>
   Boolean(user?.is_staff || (user?.directed_tournament_ids || []).length);
 
@@ -28,6 +32,10 @@ export const filterManageableTournaments = (tournaments, user) => {
 };
 
 export const fetchUserData = (successCallback, failureCallback) => {
+  if (!hasAuthHint()) {
+    failureCallback();
+    return Promise.resolve();
+  }
   return fetch("/api/me", {
     method: "GET",
     headers: { "Content-Type": "application/json" },

--- a/hub/settings.py
+++ b/hub/settings.py
@@ -57,6 +57,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "server.middleware.AuthHintCookieMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_prometheus.middleware.PrometheusAfterMiddleware",

--- a/scripts/apply-profile.py
+++ b/scripts/apply-profile.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Apply a named scaling profile from deploy/profiles.json to fly.toml.
+
+VM size, gunicorn workers/threads and the proxy concurrency limits move together:
+the limits must track workers x threads, or the proxy admits more than the app can
+serve and the excess queues until it 504s. Each edit is made exactly once and read
+back with tomllib, so a bad substitution fails here rather than at deploy time.
+
+Usage: scripts/apply-profile.py <profile> [--fly-toml PATH] [--profiles PATH]
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+ROOT = Path(__file__).parent.parent
+FLY_TOML = ROOT / "fly.toml"
+PROFILES = ROOT / "deploy" / "profiles.json"
+
+
+def _replace_once(text: str, key: str, value: str, *, quoted: bool) -> str:
+    """Replace a single `key = value` assignment, insisting it appears once."""
+    pattern = rf'^(?P<lead>[ \t]*{re.escape(key)}[ \t]*=[ \t]*)(?:"[^"]*"|\d+)[ \t]*$'
+    replacement = f'"{value}"' if quoted else value
+
+    def _substitute(match: re.Match[str]) -> str:
+        return match.group("lead") + replacement
+
+    new_text, count = re.subn(pattern, _substitute, text, flags=re.MULTILINE)
+    if count != 1:
+        sys.exit(f"error: expected exactly one '{key}' assignment in fly.toml, found {count}")
+    return new_text
+
+
+def _verify(path: Path, profile: dict[str, Any]) -> None:
+    with path.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    vm = data["vm"][0]
+    concurrency = data["services"][0]["concurrency"]
+    env = data["env"]
+    actual = {
+        "cpu_kind": vm["cpu_kind"],
+        "cpus": vm["cpus"],
+        "memory": vm["memory"],
+        "workers": int(env["GUNICORN_WORKERS"]),
+        "threads": int(env["GUNICORN_THREADS"]),
+        "soft_limit": concurrency["soft_limit"],
+        "hard_limit": concurrency["hard_limit"],
+    }
+    for key, found in actual.items():
+        expected = profile[key]
+        if found != expected:
+            sys.exit(f"error: {key} is {found!r} after writing, expected {expected!r}")
+
+    slots = actual["workers"] * actual["threads"]
+    if actual["soft_limit"] > slots:
+        sys.exit(
+            f"error: soft_limit {actual['soft_limit']} exceeds {slots} gunicorn slots "
+            f"({actual['workers']} workers x {actual['threads']} threads)"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profile", help="Profile name from deploy/profiles.json")
+    parser.add_argument("--fly-toml", type=Path, default=FLY_TOML)
+    parser.add_argument("--profiles", type=Path, default=PROFILES)
+    args = parser.parse_args()
+
+    profiles: dict[str, Any] = json.loads(args.profiles.read_text())
+    if args.profile not in profiles:
+        sys.exit(f"error: unknown profile {args.profile!r}; have {', '.join(sorted(profiles))}")
+    profile = profiles[args.profile]
+
+    text = args.fly_toml.read_text()
+    for key, toml_key, quoted in (
+        ("cpu_kind", "cpu_kind", True),
+        ("cpus", "cpus", False),
+        ("memory", "memory", True),
+        ("workers", "GUNICORN_WORKERS", True),
+        ("threads", "GUNICORN_THREADS", True),
+        ("soft_limit", "soft_limit", False),
+        ("hard_limit", "hard_limit", False),
+    ):
+        text = _replace_once(text, toml_key, str(profile[key]), quoted=quoted)
+
+    args.fly_toml.write_text(text)
+    _verify(args.fly_toml, profile)
+
+    slots = profile["workers"] * profile["threads"]
+    kind = profile["cpu_kind"]
+    size = (
+        f"shared-cpu-{profile['cpus']}x" if kind == "shared" else f"performance-{profile['cpus']}x"
+    )
+    print(
+        f"Applied '{args.profile}': {size}, {profile['memory']}, "
+        f"{profile['workers']}w x {profile['threads']}t = {slots} slots, "
+        f"limits {profile['soft_limit']}/{profile['hard_limit']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-scale.py
+++ b/scripts/check-scale.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Warn when the shared-CPU burst balance is draining for real.
+
+Depth alone cannot tell a drain from a deploy -- over the 15 days to 2026-08-28 the
+deploy dips bottomed lower (9,983 and 15,332) than the level the real incident sat
+at for six hours. Duration can: deploys recovered within 90 minutes, the incident
+never did. Hence the sustained-window test rather than a threshold.
+
+Writes `escalate=true|false` to $GITHUB_OUTPUT. Needs FLY_API_TOKEN.
+"""
+
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+ROOT = Path(__file__).parent.parent
+ORG = os.environ.get("FLY_ORG", "upai")
+APP = os.environ.get("FLY_APP", "upai-hub")
+
+SUSTAINED_CEILING = int(os.environ.get("SUSTAINED_CEILING", "60000"))
+SUSTAINED_WINDOW = os.environ.get("SUSTAINED_WINDOW", "2h")
+
+# Backstop, set below the deepest deploy dip on record (9,983).
+FLOOR = int(os.environ.get("BALANCE_FLOOR", "5000"))
+FLOOR_WINDOW = os.environ.get("FLOOR_WINDOW", "15m")
+
+
+def _query(promql: str, token: str) -> float | None:
+    url = f"https://api.fly.io/prometheus/{ORG}/api/v1/query"
+    body = urllib.parse.urlencode({"query": promql}).encode()
+    # Macaroon tokens are rejected under the Bearer scheme.
+    request = urllib.request.Request(url, data=body, headers={"Authorization": f"FlyV1 {token}"})
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+        payload: dict[str, Any] = json.load(response)
+    if payload.get("status") != "success":
+        sys.exit(f"error: Prometheus query failed: {json.dumps(payload)[:300]}")
+    results: list[dict[str, Any]] = payload["data"]["result"]
+    if not results:
+        return None
+    return float(results[0]["value"][1])
+
+
+def _current_cpu_kind() -> str:
+    with (ROOT / "fly.toml").open("rb") as handle:
+        data = tomllib.load(handle)
+    kind: str = data["vm"][0]["cpu_kind"]
+    return kind
+
+
+def _emit(escalate: bool, reason: str) -> None:
+    print(f"escalate={escalate}: {reason}")
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"escalate={'true' if escalate else 'false'}\n")
+            handle.write(f"reason={reason}\n")
+
+
+def main() -> None:
+    token = os.environ.get("FLY_API_TOKEN")
+    if not token:
+        sys.exit("error: FLY_API_TOKEN is not set")
+
+    kind = _current_cpu_kind()
+    if kind != "shared":
+        _emit(False, f"already on a {kind} profile, nothing to escalate to")
+        return
+
+    metric = f'fly_instance_cpu_balance{{app="{APP}"}}'
+    peak = _query(f"max_over_time({metric}[{SUSTAINED_WINDOW}])", token)
+    trough = _query(f"min_over_time({metric}[{FLOOR_WINDOW}])", token)
+
+    if peak is None or trough is None:
+        # Usually a stopped or just-replaced Machine. A real drain will still be
+        # there in 30 min.
+        _emit(False, "no cpu_balance samples returned")
+        return
+
+    if peak < SUSTAINED_CEILING:
+        _emit(
+            True,
+            f"balance has not recovered above {SUSTAINED_CEILING} in "
+            f"{SUSTAINED_WINDOW} (peak {peak:.0f})",
+        )
+    elif trough < FLOOR:
+        _emit(True, f"balance fell below the {FLOOR} floor (min {trough:.0f})")
+    else:
+        _emit(
+            False,
+            f"healthy: {SUSTAINED_WINDOW} peak {peak:.0f}, {FLOOR_WINDOW} min {trough:.0f}",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -1,0 +1,52 @@
+"""Custom middleware for the hub."""
+
+from collections.abc import Callable
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+
+AUTH_HINT_COOKIE = "hub_auth"
+
+
+class AuthHintCookieMiddleware:
+    """Mirror authentication state into a cookie the frontend can read.
+
+    The session cookie is HttpOnly, so the SPA could not tell it was signed out
+    without asking and taking a 401 -- 5,919 of them in the 24h to 2026-08-28. This
+    lets it skip the call. A hint only: endpoints still authenticate from the
+    session, and forging it earns nothing but a 401.
+    """
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        response = self.get_response(request)
+
+        # Reading request.user forces a session read, so only look when a session
+        # cookie is in play -- anonymous requests then cost no extra query. The
+        # outbound check covers login, which has no inbound cookie yet.
+        touches_session = (
+            settings.SESSION_COOKIE_NAME in request.COOKIES
+            or settings.SESSION_COOKIE_NAME in response.cookies
+        )
+        if touches_session:
+            user = getattr(request, "user", None)
+            is_authenticated = bool(user is not None and user.is_authenticated)
+        else:
+            is_authenticated = False
+
+        if is_authenticated:
+            # Reset on every response so it cannot expire under a live session.
+            response.set_cookie(
+                AUTH_HINT_COOKIE,
+                "1",
+                max_age=settings.SESSION_COOKIE_AGE,
+                secure=settings.SESSION_COOKIE_SECURE,
+                httponly=False,  # the point: the frontend has to read it
+                samesite="Lax",
+            )
+        elif AUTH_HINT_COOKIE in request.COOKIES:
+            response.delete_cookie(AUTH_HINT_COOKIE, samesite="Lax")
+
+        return response

--- a/server/tests/test_auth_hint.py
+++ b/server/tests/test_auth_hint.py
@@ -1,0 +1,46 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from server.middleware import AUTH_HINT_COOKIE
+
+from .test_config import TEST_PASSWORD
+
+
+class AuthHintCookieTest(TestCase):
+    def setUp(self) -> None:
+        self.user = get_user_model().objects.create_user(
+            username="hint@example.com", email="hint@example.com", password=TEST_PASSWORD
+        )
+
+    def test_anonymous_request_sets_no_hint(self) -> None:
+        response = self.client.get("/api/me")
+
+        self.assertEqual(response.status_code, 401)
+        self.assertNotIn(AUTH_HINT_COOKIE, response.cookies)
+
+    def test_authenticated_request_sets_readable_hint(self) -> None:
+        self.client.force_login(self.user)
+
+        response = self.client.get("/api/me")
+
+        self.assertEqual(response.status_code, 200)
+        cookie = response.cookies[AUTH_HINT_COOKIE]
+        self.assertEqual(cookie.value, "1")
+        self.assertFalse(cookie["httponly"])
+
+    def test_hint_is_refreshed_while_signed_in(self) -> None:
+        self.client.force_login(self.user)
+        self.client.get("/api/me")
+
+        response = self.client.get("/api/me")
+
+        self.assertEqual(response.cookies[AUTH_HINT_COOKIE].value, "1")
+
+    def test_logout_clears_the_hint(self) -> None:
+        self.client.force_login(self.user)
+        self.client.get("/api/me")
+        self.assertEqual(self.client.cookies[AUTH_HINT_COOKIE].value, "1")
+
+        response = self.client.post("/api/logout")
+
+        self.assertEqual(response.cookies[AUTH_HINT_COOKIE].value, "")


### PR DESCRIPTION
On 2026-08-28 the hub returned **1,232 504s** between 11:00Z and 16:20Z. The cause was shared-CPU burst exhaustion: sustained load drained `fly_instance_cpu_balance` from 100,000 to 1 over nine hours, after which steal took **62%** of all CPU time and requests queued until the proxy timed out. Successful throughput collapsed from 4,956/hr to 857/hr. No OOM, no crash — the database was never a factor (`active` connections sat at exactly 1.00 throughout).

Five independent changes, one per commit.

### `nginx: Cache hashed assets and compress the bundles`
Assets carry webpack/`ManifestStaticFilesStorage` content hashes, so they can be cached forever — `index.html` is rendered by Django per request and always names the current hashes, so nothing goes stale. Unhashed names get a short revalidating cache instead. Debian defaults `gzip_types` to `text/html`, so the bundles were going out uncompressed against 7.1GB of daily egress.

### `deploy: Drive the VM size and gunicorn from scaling profiles`
Two settings turned CPU starvation into an outage: the concurrency limits admitted **200 connections into 12 gunicorn slots**, and 1GB left 245MB free against a steady 716MB in use. A profile keeps VM size, worker counts and limits in step, since the limits only make sense as a multiple of `workers × threads`. Baseline moves to 2GB with 36/72 limits.

### `ci: Rebuild Fly Scale around profiles and a pull request`
The old workflow substituted four independent inputs with find-and-replace; dispatching without all four wrote `hard_limit = ` with no value — invalid TOML, and what releases v471–v473 failed on. It also committed to a dangling branch nothing merged. Now it applies a named profile and opens a PR, and never deploys.

### `ci: Warn before the CPU burst balance runs out`
A plain threshold can't read the balance, because deploys drain it too — the two deploy dips in the preceding fortnight bottomed at **9,983** and **15,332**, *lower* than the level the real incident sat at for six hours. Duration separates them. Backtested across 15 days the sustained-window test fires 23 times, all on 2026-08-28, first at **06:00Z — five hours before the first 504**.

### `auth: Stop signed-out visitors polling /api/me`
5,919 401s in 24h, ~a tenth of all requests. The session cookie is HttpOnly, so the SPA asked the server whether it was signed in — from `Header` on every page and from the public tournament and announcement routes. A non-HttpOnly mirror cookie lets it skip the call; it carries no authority, and the middleware only reads `request.user` when a session cookie is in play, so anonymous requests cost no extra query.

## Testing
`./scripts/lint` passes. Four new middleware tests cover anonymous, signed-in, refresh-while-active and real logout. All three profiles round-trip through `apply-profile.py`, and a missing key fails loudly rather than writing a half-applied profile.

## Note
Nothing here deploys. `Fly Scale` opens a PR; the autoscale guard warns rather than remediating. The guard's `schedule:` only starts once this is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)