### PR TITLE
Give the autoscale guard an org-scoped metrics token

### DIFF
--- a/.github/workflows/autoscale-guard.yml
+++ b/.github/workflows/autoscale-guard.yml
@@ -28,7 +28,9 @@ jobs:
       - name: Read cpu_balance
         id: check
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          # Must be org-scoped. FLY_API_TOKEN is the app-scoped deploy token and
+          # the org metrics endpoint answers it with a 403.
+          FLY_METRICS_TOKEN: ${{ secrets.FLY_METRICS_TOKEN }}
         run: python3 scripts/check-scale.py
 
       - name: Summary

--- a/scripts/check-scale.py
+++ b/scripts/check-scale.py
@@ -6,18 +6,22 @@ deploy dips bottomed lower (9,983 and 15,332) than the level the real incident s
 at for six hours. Duration can: deploys recovered within 90 minutes, the incident
 never did. Hence the sustained-window test rather than a threshold.
 
-Writes `escalate=true|false` to $GITHUB_OUTPUT. Needs FLY_API_TOKEN.
+Writes `escalate=true|false` to $GITHUB_OUTPUT. Needs FLY_METRICS_TOKEN, which
+must be org-scoped; the app-scoped FLY_API_TOKEN is accepted but gets a 403.
 """
 
 import json
 import os
+import re
 import sys
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
 
-import tomllib
+HTTP_FORBIDDEN = 403
+MAX_ERROR_BODY = 2048
 
 ROOT = Path(__file__).parent.parent
 ORG = os.environ.get("FLY_ORG", "upai")
@@ -31,13 +35,48 @@ FLOOR = int(os.environ.get("BALANCE_FLOOR", "5000"))
 FLOOR_WINDOW = os.environ.get("FLOOR_WINDOW", "15m")
 
 
+def http_error_message(code: int, body: bytes) -> str:
+    """A deploy token authenticates but is app-scoped, so org metrics give 403.
+    A bad token gives 401."""
+    hint = ""
+    if code == HTTP_FORBIDDEN:
+        hint = (
+            f" A deploy token cannot read org metrics -- set FLY_METRICS_TOKEN to"
+            f" a read-only org token (fly tokens create readonly -o {ORG})."
+        )
+    message = f"error: metrics API returned {code}.{hint}"
+    detail = body.decode(errors="replace").strip()
+    return f"{message} {detail}" if detail else message
+
+
+def decide(kind: str, peak: float | None, trough: float | None) -> tuple[bool, str]:
+    """Escalate only on a drain that has not recovered for the whole window; a
+    deploy dip always does."""
+    if kind != "shared":
+        return False, f"already on a {kind} profile, nothing to escalate to"
+    if peak is None or trough is None:
+        # Usually a stopped or just-replaced Machine.
+        return False, "no cpu_balance samples returned"
+    if peak < SUSTAINED_CEILING:
+        return True, (
+            f"balance has not recovered above {SUSTAINED_CEILING} in "
+            f"{SUSTAINED_WINDOW} (peak {peak:.0f})"
+        )
+    if trough < FLOOR:
+        return True, f"balance fell below the {FLOOR} floor (min {trough:.0f})"
+    return False, f"healthy: {SUSTAINED_WINDOW} peak {peak:.0f}, {FLOOR_WINDOW} min {trough:.0f}"
+
+
 def _query(promql: str, token: str) -> float | None:
     url = f"https://api.fly.io/prometheus/{ORG}/api/v1/query"
     body = urllib.parse.urlencode({"query": promql}).encode()
     # Macaroon tokens are rejected under the Bearer scheme.
     request = urllib.request.Request(url, data=body, headers={"Authorization": f"FlyV1 {token}"})
-    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
-        payload: dict[str, Any] = json.load(response)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+            payload: dict[str, Any] = json.load(response)
+    except urllib.error.HTTPError as exc:
+        sys.exit(http_error_message(exc.code, exc.read(MAX_ERROR_BODY)))
     if payload.get("status") != "success":
         sys.exit(f"error: Prometheus query failed: {json.dumps(payload)[:300]}")
     results: list[dict[str, Any]] = payload["data"]["result"]
@@ -47,10 +86,12 @@ def _query(promql: str, token: str) -> float | None:
 
 
 def _current_cpu_kind() -> str:
-    with (ROOT / "fly.toml").open("rb") as handle:
-        data = tomllib.load(handle)
-    kind: str = data["vm"][0]["cpu_kind"]
-    return kind
+    # Not tomllib: this runs on a bare runner with no install, and the repo
+    # supports Python 3.10, where tomllib does not exist.
+    match = re.search(r'^\s*cpu_kind\s*=\s*"([^"]+)"', (ROOT / "fly.toml").read_text(), re.M)
+    if match is None:
+        sys.exit("error: no cpu_kind found in fly.toml")
+    return match.group(1)
 
 
 def _emit(escalate: bool, reason: str) -> None:
@@ -63,38 +104,21 @@ def _emit(escalate: bool, reason: str) -> None:
 
 
 def main() -> None:
-    token = os.environ.get("FLY_API_TOKEN")
+    # Prefer a metrics-scoped token; FLY_API_TOKEN is the app-scoped deploy token.
+    token = os.environ.get("FLY_METRICS_TOKEN") or os.environ.get("FLY_API_TOKEN")
     if not token:
-        sys.exit("error: FLY_API_TOKEN is not set")
+        sys.exit("error: neither FLY_METRICS_TOKEN nor FLY_API_TOKEN is set")
 
     kind = _current_cpu_kind()
     if kind != "shared":
-        _emit(False, f"already on a {kind} profile, nothing to escalate to")
+        _emit(*decide(kind, None, None))
         return
 
     metric = f'fly_instance_cpu_balance{{app="{APP}"}}'
     peak = _query(f"max_over_time({metric}[{SUSTAINED_WINDOW}])", token)
     trough = _query(f"min_over_time({metric}[{FLOOR_WINDOW}])", token)
 
-    if peak is None or trough is None:
-        # Usually a stopped or just-replaced Machine. A real drain will still be
-        # there in 30 min.
-        _emit(False, "no cpu_balance samples returned")
-        return
-
-    if peak < SUSTAINED_CEILING:
-        _emit(
-            True,
-            f"balance has not recovered above {SUSTAINED_CEILING} in "
-            f"{SUSTAINED_WINDOW} (peak {peak:.0f})",
-        )
-    elif trough < FLOOR:
-        _emit(True, f"balance fell below the {FLOOR} floor (min {trough:.0f})")
-    else:
-        _emit(
-            False,
-            f"healthy: {SUSTAINED_WINDOW} peak {peak:.0f}, {FLOOR_WINDOW} min {trough:.0f}",
-        )
+    _emit(*decide(kind, peak, trough))
 
 
 if __name__ == "__main__":

--- a/server/tests/test_check_scale.py
+++ b/server/tests/test_check_scale.py
@@ -1,0 +1,118 @@
+import importlib.util
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+_PATH = Path(__file__).resolve().parent.parent.parent / "scripts" / "check-scale.py"
+_SPEC = importlib.util.spec_from_file_location("check_scale", _PATH)
+if _SPEC is None or _SPEC.loader is None:  # pragma: no cover
+    raise RuntimeError(f"cannot load {_PATH}")
+check_scale = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(check_scale)
+
+
+class DecideTest(SimpleTestCase):
+    def test_no_escalation_on_a_performance_profile(self) -> None:
+        escalate, reason = check_scale.decide("performance", None, None)
+
+        self.assertFalse(escalate)
+        self.assertIn("performance", reason)
+
+    def test_no_escalation_without_samples(self) -> None:
+        self.assertEqual(False, check_scale.decide("shared", None, None)[0])
+        self.assertEqual(False, check_scale.decide("shared", 100000.0, None)[0])
+        self.assertEqual(False, check_scale.decide("shared", None, 100000.0)[0])
+
+    def test_escalates_on_the_2026_08_28_drain(self) -> None:
+        # First firing that day: the 2h window peaked at 56,010, five hours before
+        # the first 504.
+        escalate, reason = check_scale.decide("shared", 56010.0, 41134.0)
+
+        self.assertTrue(escalate)
+        self.assertIn("56010", reason)
+
+    def test_does_not_escalate_on_a_deploy_dip(self) -> None:
+        # 2026-08-20 bottomed at 9,983 but recovered inside 90 minutes, so the 2h
+        # window still contains a healthy reading. Depth alone would have fired.
+        escalate, _ = check_scale.decide("shared", 100000.0, 9983.0)
+
+        self.assertFalse(escalate)
+
+    def test_floor_is_a_backstop_for_a_faster_drain(self) -> None:
+        escalate, reason = check_scale.decide("shared", 100000.0, 4999.0)
+
+        self.assertTrue(escalate)
+        self.assertIn("floor", reason)
+
+    def test_healthy_balance_does_not_escalate(self) -> None:
+        escalate, reason = check_scale.decide("shared", 200000.0, 199837.0)
+
+        self.assertFalse(escalate)
+        self.assertIn("healthy", reason)
+
+
+class HttpErrorMessageTest(SimpleTestCase):
+    def test_403_explains_the_token_scope(self) -> None:
+        message = check_scale.http_error_message(403, b"Forbidden")
+
+        self.assertIn("403", message)
+        self.assertIn("FLY_METRICS_TOKEN", message)
+        self.assertIn("Forbidden", message)
+
+    def test_other_codes_carry_no_token_hint(self) -> None:
+        message = check_scale.http_error_message(500, b"boom")
+
+        self.assertNotIn("FLY_METRICS_TOKEN", message)
+        self.assertIn("boom", message)
+
+    def test_empty_body_leaves_no_trailing_space(self) -> None:
+        message = check_scale.http_error_message(502, b"   ")
+
+        self.assertEqual(message, message.rstrip())
+
+
+class EmitTest(SimpleTestCase):
+    def _emit_to_file(self, escalate: bool, reason: str) -> str:
+        with tempfile.NamedTemporaryFile("w+", delete=False) as handle:
+            path = handle.name
+        try:
+            with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": path}):
+                check_scale._emit(escalate, reason)
+            return Path(path).read_text()
+        finally:
+            Path(path).unlink()
+
+    def test_writes_github_output(self) -> None:
+        contents = self._emit_to_file(True, "drain detected")
+
+        self.assertIn("escalate=true\n", contents)
+        self.assertIn("reason=drain detected\n", contents)
+
+    def test_writes_lowercase_false(self) -> None:
+        self.assertIn("escalate=false\n", self._emit_to_file(False, "healthy"))
+
+    def test_without_github_output_it_only_prints(self) -> None:
+        with mock.patch.dict(os.environ, clear=False) as env:
+            env.pop("GITHUB_OUTPUT", None)
+            check_scale._emit(False, "healthy")
+
+
+class CurrentCpuKindTest(SimpleTestCase):
+    def test_reads_the_live_fly_toml(self) -> None:
+        # Guards the field path into fly.toml.
+        self.assertIn(check_scale._current_cpu_kind(), {"shared", "performance"})
+
+
+class MainTest(SimpleTestCase):
+    def test_exits_when_no_token_is_set(self) -> None:
+        with mock.patch.dict(os.environ, clear=False) as env:
+            env.pop("FLY_METRICS_TOKEN", None)
+            env.pop("FLY_API_TOKEN", None)
+
+            with self.assertRaises(SystemExit) as caught:
+                check_scale.main()
+
+        self.assertIn("FLY_METRICS_TOKEN", str(caught.exception))


### PR DESCRIPTION
Every scheduled `Autoscale Guard` run since it landed has failed:

```
urllib.error.HTTPError: HTTP Error 403: Forbidden
```

## Cause

`FLY_API_TOKEN` (created 2023-07-06) is the **app-scoped deploy token**. It authenticates correctly — which is why the failure is a **403 and not a 401** — but the org-level Prometheus endpoint `api.fly.io/prometheus/upai/` is outside its scope.

Verified: a deliberately bogus token returns **401** with `something went wrong resolving organization`, while a personal org token returns **200** against the identical query. So this is an authorisation gap, not a bad credential.

## Change

The guard now reads `FLY_METRICS_TOKEN`. The deploy token stays app-scoped rather than being widened, so the blast radius of the more widely used secret is unchanged.

HTTP errors now report status and body instead of a `urllib` traceback — the traceback didn't distinguish "wrong token" from "wrong scope", which is the whole question here.

```
error: metrics API returned 403. A deploy token cannot read org metrics --
set FLY_METRICS_TOKEN to a read-only org token
(fly tokens create readonly -o upai). <body>
```

## Required before this works

This PR alone does not fix the failures — the secret has to exist:

```sh
fly tokens create readonly -o upai
gh secret set FLY_METRICS_TOKEN   # paste the token
```

Until then the guard fails with `neither FLY_METRICS_TOKEN nor FLY_API_TOKEN is set`, which is at least the actionable version of the message.

Note the org already has a `Read-only org token` (expires 2046). If its value was saved somewhere, it can be reused instead of minting a new one.

## Testing
`./scripts/lint` passes. Ran locally against the live API: a valid token reports `healthy: 2h peak 200000, 15m min 199948`; an invalid one exits 1 with the status and body and no traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)