### PR TITLE
deploy: Scale to the tournament profile

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -22,12 +22,12 @@ swap_size_mb = 512
   PORT = "8000"
   DJANGO_SETTINGS_MODULE = "hub.production"
   # Set by scripts/apply-profile.py; workers x threads must track the limits below.
-  GUNICORN_WORKERS = "6"
-  GUNICORN_THREADS = "6"
+  GUNICORN_WORKERS = "2"
+  GUNICORN_THREADS = "12"
 
 [[vm]]
-  cpu_kind = "shared"
-  cpus = 4
+  cpu_kind = "performance"
+  cpus = 1
   memory = "2gb"
 
 [[services]]
@@ -45,8 +45,8 @@ swap_size_mb = 512
     handlers = ["tls", "http"]
   [services.concurrency]
     type = "connections"
-    hard_limit = 72
-    soft_limit = 36
+    hard_limit = 48
+    soft_limit = 24
 
   [[services.tcp_checks]]
     interval = "15s"


### PR DESCRIPTION
Switches `fly.toml` to the `tournament` profile from `deploy/profiles.json`.

| | baseline | tournament |
|---|---|---|
| CPU | shared-cpu-4x | **performance-1x** |
| memory | 2gb | 2gb |
| gunicorn | 6w × 6t = 36 slots | 2w × 12t = 24 slots |
| limits | 36 / 72 | 24 / 48 |

**Why performance-1x:** a dedicated vCPU has no burst balance to exhaust, so the throttle cliff behind the 2026-08-28 outage cannot recur. Measured real CPU demand peaked at **~0.28 CPU-equivalents** during the busiest hour in the 15-day window, so 1.0 dedicated leaves ~3.6x headroom.

**Why fewer workers:** on a single core, two processes with deep thread pools beat six competing for it, and the workload is I/O-bound (waiting on the LLM provider and Postgres). Limits track the resulting 24 slots so the proxy sheds at the edge instead of queueing past the timeout.

Note this trades burst ceiling for a floor: `baseline` can spike to 4 cores while credits last, `performance-1x` is flat at 1. The static-asset caching already on `main` removes most of the spiky load that made that matter.

## Deploying
Merging does not deploy. Run **Fly Deploy** afterwards. Scale back down by running **Fly Scale** with the `baseline` profile once the event is over.

Costs ~$32.19/month while it runs, vs ~$13.08 for baseline — about **$2.15 for a two-day event**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)