### PR TITLE
deploy: Scale to the peak profile

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -22,13 +22,13 @@ swap_size_mb = 512
   PORT = "8000"
   DJANGO_SETTINGS_MODULE = "hub.production"
   # Set by scripts/apply-profile.py; workers x threads must track the limits below.
-  GUNICORN_WORKERS = "2"
-  GUNICORN_THREADS = "12"
+  GUNICORN_WORKERS = "4"
+  GUNICORN_THREADS = "8"
 
 [[vm]]
   cpu_kind = "performance"
-  cpus = 1
-  memory = "2gb"
+  cpus = 2
+  memory = "4gb"
 
 [[services]]
   protocol = "tcp"
@@ -45,8 +45,8 @@ swap_size_mb = 512
     handlers = ["tls", "http"]
   [services.concurrency]
     type = "connections"
-    hard_limit = 48
-    soft_limit = 24
+    hard_limit = 64
+    soft_limit = 32
 
   [[services.tcp_checks]]
     interval = "15s"


### PR DESCRIPTION
Switches `fly.toml` to the `peak` profile from `deploy/profiles.json`. Main currently carries `tournament` (#563, merged 06:30Z), so this is the step up from there.

| | tournament (on main) | peak |
|---|---|---|
| CPU | performance-1x | **performance-2x** |
| memory | 2gb | **4gb** |
| gunicorn | 2w × 12t = 24 slots | 4w × 8t = 32 slots |
| limits | 24 / 48 | 32 / 64 |

**Headroom:** measured real CPU demand peaked at **~0.28 CPU-equivalents** during the busiest hour in the 15-day window. Two dedicated vCPUs is ~7x that, against ~3.6x for `tournament`. Like `tournament`, there's no burst balance, so no throttle cliff.

**Why more workers here:** a second core makes additional processes worth having, where on one core the deeper thread pool was the better shape.

**On the memory:** 4GB comes with `performance-2x` regardless, and it matters more than the numbers suggest. The base footprint is ~716MB and gunicorn workers fork copy-on-write — going 2→4 workers previously moved total usage by ~11MB. So RAM was never constraining worker count; it was constraining headroom, and 2GB left ~1.3GB of it.

Use this for finals or anything unusual. `tournament` is the cheaper default for ordinary event days.

## Deploying
Merging does not deploy — run **Fly Deploy** after. Scale back with **Fly Scale** (`baseline`) once the event ends.

~$64.39/month while it runs, about **$4.29 for a two-day event**, vs ~$2.15 on `tournament`.

Note the autoscale guard stays inert on any `performance` profile, since there's no burst balance to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)