### PR TITLE
Stop Fly Scale pushing into an occupied ref namespace

### DIFF
--- a/.github/workflows/scale.yml
+++ b/.github/workflows/scale.yml
@@ -73,7 +73,9 @@ jobs:
           REASON: ${{ inputs.reason || 'Requested manually' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="fly-scale/$PROFILE-$(date -u +%Y%m%d-%H%M%S)"
+          # Hyphen, not a slash: refs/heads/fly-scale already exists as a branch,
+          # so anything under fly-scale/ is rejected as a directory file conflict.
+          BRANCH="fly-scale-$PROFILE-$(date -u +%Y%m%d-%H%M%S)"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"


### PR DESCRIPTION
Both `Fly Scale` runs on 2026-08-30 (06:26Z and 06:30Z) failed at the push step:

```
 ! [remote rejected] fly-scale/tournament-20260830-063016
   -> fly-scale/tournament-20260830-063016 (directory file conflict)
error: failed to push some refs
```

## Cause

`refs/heads/fly-scale` **already exists as a branch** — `6f05e63`, "Commit from GitHub Actions (Fly Scale)", pushed 2025-01-10 by an older version of this same workflow.

Git stores refs as files on disk, so `refs/heads/fly-scale` cannot simultaneously be a file (the branch) and a directory (holding `fly-scale/tournament-…`). Every run using the `fly-scale/` prefix is rejected, deterministically.

## Fix

One character: `fly-scale/$PROFILE-…` → `fly-scale-$PROFILE-…`. The new branches become siblings of `fly-scale` rather than children, which is also the convention the pre-existing ones already follow:

```
fly-scale                    <- the blocker
fly-scale-cpu
fly-scale-1743651285326
fly-scale-1760809874160
fly-scale-1787872977478
fly-scale-1787920343144
fly-scale-<profile>-<ts>     <- new form, no collision
```

Chose renaming over deleting `fly-scale`, since that branch belongs to someone else and deleting it wouldn't stop the same collision recurring if it were ever recreated.

## Note
This is why the tournament profile went in via a hand-opened PR (#563) rather than through the workflow. Worth garbage-collecting the five stale `fly-scale-*` branches separately — two of them (`…787872977478`, `…787920343144`) are from the 2026-08-28 outage, and one carries the invalid `hard_limit = ` config that failed releases v471–v473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)