### PR TITLE
Rank spirit scores on the average, not the rounded value

### DIFF
--- a/frontend/src/components/Tournament.js
+++ b/frontend/src/components/Tournament.js
@@ -454,9 +454,9 @@ const Tournament = () => {
                             </A>
                           </td>
                           <td class="py-4 pl-2 pr-6">
-                            {spirit.points}
+                            {spirit.points?.toFixed(2)}
                             <Show when={spirit.self_points}>
-                              ({spirit.self_points})
+                              ({spirit.self_points?.toFixed(2)})
                             </Show>
                           </td>
                         </tr>

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -1591,19 +1591,19 @@ class TestTournaments(ApiBaseTestCase):
         self.assertEqual(3, match["self_spirit_score_team_2"]["rules"])
         self.assertEqual(2, match["self_spirit_score_team_2"]["fouls"])
 
+        # Level teams are separated by final placement, so ranks are sequential.
         expected_tournament_spirit_ranking = [
             {"team_id": 2, "points": 11.0, "self_points": 11.0, "rank": 1},
             {"team_id": 1, "points": 9.0, "self_points": 10.0, "rank": 2},
             {"team_id": 3, "points": 0.0, "self_points": 0.0, "rank": 3},
-            {"team_id": 4, "points": 0.0, "self_points": 0.0, "rank": 3},
-            {"team_id": 5, "points": 0.0, "self_points": 0.0, "rank": 3},
-            {"team_id": 6, "points": 0.0, "self_points": 0.0, "rank": 3},
-            {"team_id": 7, "points": 0.0, "self_points": 0.0, "rank": 3},
-            {"team_id": 8, "points": 0.0, "self_points": 0.0, "rank": 3},
+            {"team_id": 4, "points": 0.0, "self_points": 0.0, "rank": 4},
+            {"team_id": 5, "points": 0.0, "self_points": 0.0, "rank": 5},
+            {"team_id": 6, "points": 0.0, "self_points": 0.0, "rank": 6},
+            {"team_id": 7, "points": 0.0, "self_points": 0.0, "rank": 7},
+            {"team_id": 8, "points": 0.0, "self_points": 0.0, "rank": 8},
         ]
 
         self.tournament.refresh_from_db()
-        print(self.tournament.spirit_ranking)
         self.assertEqual(expected_tournament_spirit_ranking, self.tournament.spirit_ranking)
 
     def test_invalid_submit_spirit_score(self) -> None:

--- a/server/tests/test_spirit_ranking.py
+++ b/server/tests/test_spirit_ranking.py
@@ -1,0 +1,66 @@
+from django.test import SimpleTestCase
+
+from server.tournament.utils import rank_spirit_scores
+
+# current_seeding, {position: team_id}: Karnataka 1st, Bengal 2nd, Kerala 3rd.
+FINAL_STANDINGS = {"1": 1, "2": 3, "3": 2}
+
+
+class RankSpiritScoresTest(SimpleTestCase):
+    def test_ranks_on_the_true_average_not_the_displayed_one(self) -> None:
+        scores = [
+            {"team_id": 1, "points": 83 / 8, "self_points": 10.0},  # Karnataka 10.375
+            {"team_id": 2, "points": 73 / 7, "self_points": 10.0},  # Kerala    10.4286
+            {"team_id": 3, "points": 83.2 / 8, "self_points": 10.0},  # Bengal  10.4
+        ]
+
+        ranked = rank_spirit_scores(scores, FINAL_STANDINGS)
+
+        self.assertEqual([2, 3, 1], [s["team_id"] for s in ranked])
+        self.assertEqual([1, 2, 3], [s["rank"] for s in ranked])
+        self.assertEqual([10.43, 10.4, 10.38], [s["points"] for s in ranked])
+
+    def test_level_teams_are_separated_by_final_placement(self) -> None:
+        scores = [
+            {"team_id": 2, "points": 10.4, "self_points": 9.0},
+            {"team_id": 3, "points": 10.4, "self_points": 9.0},
+            {"team_id": 1, "points": 10.4, "self_points": 9.0},
+        ]
+
+        ranked = rank_spirit_scores(scores, FINAL_STANDINGS)
+
+        self.assertEqual([1, 3, 2], [s["team_id"] for s in ranked])
+        self.assertEqual([1, 2, 3], [s["rank"] for s in ranked])
+
+    def test_float_noise_does_not_pose_as_a_tie_break(self) -> None:
+        # Ten matches of 10.4 average to 10.400000000000002.
+        accumulated = 0.0
+        for _ in range(10):
+            accumulated += 10.4
+        scores = [
+            {"team_id": 2, "points": accumulated / 10, "self_points": 9.0},
+            {"team_id": 1, "points": 10.4, "self_points": 9.0},
+        ]
+
+        ranked = rank_spirit_scores(scores, FINAL_STANDINGS)
+
+        self.assertEqual([1, 2], [s["team_id"] for s in ranked])
+
+    def test_unplaced_teams_sort_behind_placed_ones(self) -> None:
+        scores = [
+            {"team_id": 99, "points": 10.4, "self_points": 9.0},
+            {"team_id": 1, "points": 10.4, "self_points": 9.0},
+        ]
+
+        ranked = rank_spirit_scores(scores, FINAL_STANDINGS)
+
+        self.assertEqual([1, 99], [s["team_id"] for s in ranked])
+
+    def test_works_without_standings_or_self_points(self) -> None:
+        # Migration 0039 calls this with one argument.
+        ranked = rank_spirit_scores(
+            [{"team_id": 9, "points": 11.0}, {"team_id": 8, "points": 12.0}]
+        )
+
+        self.assertEqual([8, 9], [s["team_id"] for s in ranked])
+        self.assertEqual([1, 2], [s["rank"] for s in ranked])

--- a/server/tournament/utils.py
+++ b/server/tournament/utils.py
@@ -1770,17 +1770,16 @@ def update_tournament_spirit_rankings(tournament: Tournament) -> None:
 
                 matches_count += 1
 
+        # Rounded by rank_spirit_scores, after ranking.
         spirit_ranking.append(
             {
                 "team_id": team.id,
-                "points": round(points / matches_count, ndigits=1) if matches_count > 0 else points,
-                "self_points": round(self_points / matches_count, ndigits=1)
-                if matches_count > 0
-                else self_points,
+                "points": points / matches_count if matches_count > 0 else points,
+                "self_points": self_points / matches_count if matches_count > 0 else self_points,
             }
         )
 
-    tournament.spirit_ranking = rank_spirit_scores(spirit_ranking)
+    tournament.spirit_ranking = rank_spirit_scores(spirit_ranking, tournament.current_seeding)
     tournament.save()
 
 
@@ -1992,15 +1991,35 @@ def create_bracket_sequence_matches(
         )
 
 
-def rank_spirit_scores(scores: list[dict[str, int | float]]) -> list[dict[str, int | float]]:
-    spirit_points = sorted({r["points"] for r in scores}, reverse=True)
+def rank_spirit_scores(
+    scores: list[dict[str, int | float]],
+    final_standings: dict[str, int] | None = None,
+) -> list[dict[str, int | float]]:
+    """Rank by average spirit score, ties broken by final placement.
 
-    # Assign the ranks to teams based on points - use the same rank for teams
-    # with same number of points.
-    for score in scores:
-        score["rank"] = spirit_points.index(score["points"]) + 1
+    final_standings is current_seeding, {position: team_id}. Unplaced teams sort last.
+    """
+    placement: dict[int, int] = {
+        int(team_id): int(position) for position, team_id in (final_standings or {}).items()
+    }
+    unplaced = len(placement) + 1
 
-    return sorted(scores, key=lambda x: x["rank"])
+    def rank_key(score: dict[str, int | float]) -> tuple[float, int]:
+        # Six decimals so float noise cannot pre-empt the placement tie-break.
+        return (
+            -round(float(score["points"]), 6),
+            placement.get(int(score["team_id"]), unplaced),
+        )
+
+    ranked = sorted(scores, key=rank_key)
+    for position, score in enumerate(ranked, start=1):
+        score["rank"] = position
+        score["points"] = round(float(score["points"]), 2)
+        # Migration 0039 predates self_points.
+        if "self_points" in score:
+            score["self_points"] = round(float(score["self_points"]), 2)
+
+    return ranked
 
 
 def update_for_pool_or_position_pool(match: Match, pool: Pool | PositionPool) -> None:


### PR DESCRIPTION
Kerala's spirit captain reported a three-way tie at 10.4 between Bengal, Kerala and Karnataka that shouldn't have been one:

```
Karnataka  83/8 = 10.375
Kerala     73/7 = 10.4286
```

Both displayed as 10.4 — and both were being *ranked* as 10.4.

## Cause

`update_tournament_spirit_rankings` rounded the average to one decimal **before storing it**, and `rank_spirit_scores` built its order from the set of distinct rounded values:

```python
spirit_points = sorted({r["points"] for r in scores}, reverse=True)
score["rank"] = spirit_points.index(score["points"]) + 1
```

So any teams sharing a displayed figure necessarily shared a rank. Kerala and Karnataka are 0.054 apart — more than half a rounding step.

```
team    total   n     true avg    before          after
KL         73   7    10.428571    10.4  rank 1    10.43  rank 1
BT       83.2   8    10.400000    10.4  rank 1    10.40  rank 2
KA         83   8    10.375000    10.4  rank 1    10.38  rank 3
```

The *rounding* was correct — 10.375 → 10.4 is proper. Ranking on the rounded value was the defect.

## Change

- **Ranks come from the unrounded average.**
- **Ties break on final placement**, read from `current_seeding` (`{position: team_id}`). Ranks are consequently sequential where equal scores used to share one — visible in the updated `test_api.py` expectation, where six teams on 0.0 move from all-rank-3 to ranks 3–8 in finishing order.
- **Scores are kept and shown to two decimals** (backend rounds to 2; the table uses `toFixed(2)`), so these three now read 10.43 / 10.40 / 10.38 instead of three identical 10.4s.
- Averages are compared at **six decimals** when ranking. Ten matches of 10.4 accumulate to `10.400000000000002`, and raw float comparison would rank that above an exact 10.4 on representation alone, silently pre-empting the placement tie-break.

`final_standings` is optional because migration `0039` still calls this with one argument, on rankings recorded before `self_points` existed — covered by a test.

## Testing
`./scripts/lint` passes. Five tests in `server/tests/test_spirit_ranking.py` use the real BT/KL/KA figures. Full suite: 489 tests, 3 errors, all pre-existing and unrelated (`TOPSCORE_CLIENT_ID` env var, two SeleniumBase UI tests).

## Note
**Standings won't change on merge.** `spirit_ranking` is stored JSON, recomputed only when a spirit score in that tournament is next saved (`api.py:2618`, `2652`). The affected tournament needs a recompute — happy to add a management command if that's easier than re-saving a score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)